### PR TITLE
Docker compose profile for API debugging

### DIFF
--- a/build/aggregator-kh.Dockerfile
+++ b/build/aggregator-kh.Dockerfile
@@ -1,3 +1,0 @@
-FROM clickhouse/clickhouse-server:22.11
-COPY build/clickhouse.sql /docker-entrypoint-initdb.d/
-COPY build/clickhouse-config.xml /etc/clickhouse-server/config.d/

--- a/build/clickhouse.Dockerfile
+++ b/build/clickhouse.Dockerfile
@@ -1,2 +1,3 @@
 FROM clickhouse/clickhouse-server:22.11
 COPY build/clickhouse.sql /docker-entrypoint-initdb.d/
+COPY build/clickhouse-config.xml /etc/clickhouse-server/config.d/

--- a/build/prometheus.yml
+++ b/build/prometheus.yml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 1s # Default is every 1 minute.
+
+scrape_configs:
+- job_name: 'demo'
+  static_configs:
+    - targets:
+      - 'demo.promlabs.com:10000'
+      - 'demo.promlabs.com:10001'
+      - 'demo.promlabs.com:10002'
+
+remote_write:
+- url: http://agent:8081/write

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   metadata:
     profiles:
       - sh
+      - api-dev
     build:
       context: .
       dockerfile: build/statshouse-metadata.Dockerfile
@@ -11,19 +12,25 @@ services:
         - BUILD_TRUSTED_SUBNET_GROUPS=0.0.0.0/0
     container_name: sh-metadata
     command: --statshouse-addr=agent:13337 --db-path=/var/lib/statshouse/metadata/db --binlog-prefix=/var/lib/statshouse/metadata/binlog/bl
-    expose:
-      - 2442
-  aggregator-kh:
+    volumes:
+      - metadata:/var/lib/statshouse
+    ports:
+      - "2442:2442"
+  kh:
     profiles:
       - sh
+      - kh
+      - api-dev
     build:
       context: .
-      dockerfile: build/aggregator-kh.Dockerfile
-    container_name: sh-aggregator-kh
+      dockerfile: build/clickhouse.Dockerfile
+    container_name: kh
     hostname: aggregator
-    expose:
-      - 8123
-      - 9000
+    volumes:
+      - kh:/var/lib/clickhouse
+    ports:
+      - "8123:8123"
+      - "9000:9000"
     healthcheck:
       test: ["CMD-SHELL", "clickhouse-client --query='SELECT 1'"]
       interval: 200ms
@@ -32,21 +39,23 @@ services:
   aggregator:
     profiles:
       - sh
+      - api-dev
     build:
       context: .
       dockerfile: build/statshouse.Dockerfile
       args:
         - BUILD_TRUSTED_SUBNET_GROUPS=0.0.0.0/0
     container_name: sh-aggregator
-    command: aggregator --cluster=test_shard_aggregator --log-level=trace --agg-addr=':13336' --kh=aggregator-kh:8123 --metadata-addr=metadata:2442 --auto-create --cache-dir=/var/lib/statshouse/cache/aggregator
+    command: aggregator --cluster=test_shard_aggregator --log-level=trace --agg-addr=':13336' --kh=kh:8123 --metadata-addr=metadata:2442 --auto-create --cache-dir=/var/lib/statshouse/cache/aggregator
     expose:
       - 13336
     depends_on:
-      aggregator-kh:
+      kh:
         condition: service_healthy
   agent:
     profiles:
       - sh
+      - api-dev
     build:
       context: .
       dockerfile: build/statshouse.Dockerfile
@@ -54,8 +63,9 @@ services:
         - BUILD_TRUSTED_SUBNET_GROUPS=0.0.0.0/0
     container_name: sh-agent
     command: agent --cluster=test_shard_aggregator --log-level=trace --agg-addr='aggregator:13336,aggregator:13336,aggregator:13336' --cache-dir=/var/lib/statshouse/cache/agent --remote-write-enabled
+    expose:
+      - 8081
     ports:
-      - "8081:8081"
       - "13337:13337/udp"
     depends_on:
       - aggregator
@@ -68,30 +78,45 @@ services:
       args:
         - BUILD_TRUSTED_SUBNET_GROUPS=0.0.0.0/0
     container_name: sh-api
-    command: --verbose --local-mode --access-log --clickhouse-v1-addrs= --clickhouse-v2-addrs=aggregator-kh:9000 --listen-addr=:10888 --metadata-addr=metadata:2442 --statshouse-addr=agent:13337 --disk-cache=/var/lib/statshouse/cache/api/mapping_cache.sqlite3
+    command: --verbose --local-mode --access-log --clickhouse-v1-addrs= --clickhouse-v2-addrs=kh:9000 --listen-addr=:10888 --metadata-addr=metadata:2442 --statshouse-addr=agent:13337 --disk-cache=/var/lib/statshouse/cache/api/mapping_cache.sqlite3
     ports:
       - "10888:10888"
     depends_on:
-      aggregator-kh:
+      kh:
         condition: service_healthy
-  kh:
-    profiles:
-      - kh
-    build:
-      context: .
-      dockerfile: build/clickhouse.Dockerfile
-    ports:
-      - "8123:8123"
-      - "9000:9000"
   all-in-one:
     profiles:
       - all-in-one
     build:
       context: .
       dockerfile: build/all-in-one.Dockerfile
-      args:
-        - BUILD_TRUSTED_SUBNET_GROUPS=0.0.0.0/0
     container_name: all-in-one
     ports:
       - "10888:10888"
       - "13337:13337/udp"
+  grafana:
+    profiles:
+      - api-dev
+    image: grafana/grafana-oss
+    container_name: grafana
+    volumes:
+      - grafana:/var/lib/grafana
+    expose:
+      - 3000
+    network_mode: host
+  prometheus:
+    profiles:
+      - api-dev
+    image: prom/prometheus
+    container_name: prometheus
+    volumes:
+      - prometheus:/prometheus
+      - ${PWD}/build/prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+
+volumes:
+  kh:
+  metadata:
+  prometheus:
+  grafana:

--- a/localrun.sh
+++ b/localrun.sh
@@ -1,15 +1,22 @@
 #!/bin/bash
 set -e
 
-docker compose --profile sh up -d --build
-trap "{ docker compose --profile sh down; exit; }" exit
+PROFILE=sh
+if [[ $1 ]]; then
+  PROFILE=$1
+fi
+
+docker compose --profile "$PROFILE" up -d --build
+trap "{ docker compose --profile $PROFILE down; exit; }" exit
 echo -n Waiting for services to be ready...
-until docker exec sh-aggregator-kh clickhouse-client --query='SELECT 1' >/dev/null 2>&1; do echo -n .; sleep 0.2; done
-until curl --output /dev/null --silent --head --fail http://localhost:10888/; do echo -n .; sleep 0.2; done
+until docker exec kh clickhouse-client --query='SELECT 1' >/dev/null 2>&1; do echo -n .; sleep 0.2; done
+if [ "$(docker container inspect -f '{{.State.Status}}' sh-api 2>/dev/null)" = "running" ]; then
+  until curl --output /dev/null --silent --head --fail http://localhost:10888/; do echo -n .; sleep 0.2; done
+  URL="http://localhost:10888/view?live&f=-300&t=0&s=__contributors_log_rev"
+  case "$OSTYPE" in
+    darwin*)  open "$URL" ;;
+    linux*)   xdg-open "$URL" ;;
+  esac
+fi
 echo READY
-URL="http://localhost:10888/view?live&f=-300&t=0&s=__contributors_log_rev"
-case "$OSTYPE" in
-  darwin*)  open "$URL" ;;
-  linux*)   xdg-open "$URL" ;;
-esac
 read -r -p "Press ENTER key or CTRL+C to exit."


### PR DESCRIPTION
* Start StatsHouse (except API), grafana and prometheus with ./localrun api-dev
* Prom scrapes demo.promlabs.com server and sends data to StatsHouse
* Run StatsHouse API under debugger with command line below --verbose --local-mode --access-log --clickhouse-v1-addrs= --clickhouse-v2-addrs=localhost:9000 --listen-addr=:10888 --metadata-addr=localhost:2442 --statshouse-addr=localhost:13337 --disk-cache=<disk_cache_path> --static-dir=statshouse-ui/build
* Open http://localhost:10888/view?live=&f=-300&t=0&s=__contributors_log_rev