### PR TITLE
Update localrun

### DIFF
--- a/build/all-in-one-entrypoint.sh
+++ b/build/all-in-one-entrypoint.sh
@@ -4,11 +4,12 @@ set -e
 /bin/statshouse-metadata --db-path=/var/lib/statshouse/metadata/db --binlog-prefix=/var/lib/statshouse/metadata/binlog/bl &
 until clickhouse-client --query="SELECT 1"; do sleep 0.2; done
 /bin/statshouse aggregator --cluster=test_shard_localhost --log-level=trace --agg-addr=':13336' --kh=127.0.0.1:8123 \
-  --auto-create --cache-dir=/var/lib/statshouse/cache/aggregator &
+  --auto-create --cache-dir=/var/lib/statshouse/cache/aggregator -u=root -g=root &
 /bin/statshouse agent --cluster=test_shard_localhost --log-level=trace --remote-write-enabled \
-  --agg-addr='127.0.0.1:13336,127.0.0.1:13336,127.0.0.1:13336' --cache-dir=/var/lib/statshouse/cache/agent &
+  --agg-addr='127.0.0.1:13336,127.0.0.1:13336,127.0.0.1:13336' --cache-dir=/var/lib/statshouse/cache/agent \
+  -u=root -g=root &
 /bin/statshouse-api --verbose --local-mode --access-log --clickhouse-v1-addrs= --clickhouse-v2-addrs=127.0.0.1:9000 \
-  --listen-addr=:10888 --statshouse-addr=agent:13337 --disk-cache=/var/lib/statshouse/cache/api/mapping_cache.sqlite3 \
+  --listen-addr=:10888 --statshouse-addr=127.0.0.1:13337 --disk-cache=/var/lib/statshouse/cache/api/mapping_cache.sqlite3 \
   --static-dir=/usr/lib/statshouse-api/statshouse-ui/ &
 wait -n
 exit $?

--- a/build/all-in-one.Dockerfile
+++ b/build/all-in-one.Dockerfile
@@ -29,22 +29,20 @@ WORKDIR /src
 COPY go.mod go.sum Makefile ./
 COPY cmd/ ./cmd/
 COPY internal/ ./internal/
-RUN go mod download
+RUN go mod download -x
 RUN make build-sh build-sh-api build-sh-metadata
 
 FROM clickhouse/clickhouse-server:22.11
-RUN groupadd kitten
-RUN useradd -g kitten kitten
-RUN mkdir -p /var/lib/statshouse/cache/aggregator
-RUN mkdir -p /var/lib/statshouse/cache/agent
-RUN mkdir -p /var/lib/statshouse/cache/api
-RUN mkdir -p /var/lib/statshouse/metadata/binlog
+WORKDIR /var/lib/statshouse/cache/aggregator
+WORKDIR /var/lib/statshouse/cache/agent
+WORKDIR /var/lib/statshouse/cache/api
+WORKDIR /var/lib/statshouse/metadata/binlog
+WORKDIR /var/lib/statshouse
 COPY build/clickhouse.sql /docker-entrypoint-initdb.d/
 COPY build/all-in-one-entrypoint.sh /bin/
 COPY --from=build-go /src/target/statshouse /bin/
 COPY --from=build-go /src/target/statshouse-api /bin/
 COPY --from=build-go /src/target/statshouse-metadata /bin/
 COPY --from=build-node /src/statshouse-ui/build /usr/lib/statshouse-api/statshouse-ui/
-RUN /bin/statshouse-metadata --binlog-prefix "/var/lib/statshouse/metadata/binlog/bl" --create-binlog "0,1"
-RUN chown -R kitten:kitten /var/lib/statshouse
+RUN ["/bin/statshouse-metadata", "--binlog-prefix=/var/lib/statshouse/metadata/binlog/bl", "--create-binlog=0,1"]
 ENTRYPOINT ["/bin/all-in-one-entrypoint.sh"]

--- a/build/statshouse-api.Dockerfile
+++ b/build/statshouse-api.Dockerfile
@@ -29,12 +29,12 @@ WORKDIR /src
 COPY go.mod go.sum Makefile ./
 COPY cmd/ ./cmd/
 COPY internal/ ./internal/
-RUN go mod download
+RUN go mod download -x
 RUN make build-sh-api
-RUN mkdir -p /var/lib/statshouse/cache/api
 
 FROM gcr.io/distroless/base-debian11:nonroot
+WORKDIR /var/lib/statshouse/cache/api
+WORKDIR /home/nonroot
 COPY --from=build-go /src/target/statshouse-api /bin/
-COPY --from=build-go --chown=nonroot:nonroot /var/lib/statshouse/ /var/lib/statshouse/
 COPY --from=build-node /src/statshouse-ui/build /usr/lib/statshouse-api/statshouse-ui/
 ENTRYPOINT ["/bin/statshouse-api", "--static-dir=/usr/lib/statshouse-api/statshouse-ui/"]

--- a/build/statshouse.Dockerfile
+++ b/build/statshouse.Dockerfile
@@ -13,16 +13,16 @@ ENV BUILD_COMMIT_TS=$BUILD_COMMIT_TS
 ENV BUILD_ID=$BUILD_ID
 ENV BUILD_VERSION=$BUILD_VERSION
 ENV BUILD_TRUSTED_SUBNET_GROUPS=$BUILD_TRUSTED_SUBNET_GROUPS
-RUN mkdir -p /var/lib/statshouse/cache/aggregator
-RUN mkdir -p /var/lib/statshouse/cache/agent
 WORKDIR /src
 COPY go.mod go.sum Makefile ./
 COPY cmd/ ./cmd/
 COPY internal/ ./internal/
-RUN go mod download
+RUN go mod download -x
 RUN make build-sh
 
 FROM gcr.io/distroless/base-debian11:nonroot
-COPY --from=build /src/target/statshouse /bin/
-COPY --from=build --chown=nonroot:nonroot /var/lib/statshouse/ /var/lib/statshouse/
+WORKDIR /var/lib/statshouse/cache/aggregator
+WORKDIR /var/lib/statshouse/cache/agent
+WORKDIR /home/nonroot
+COPY --from=build /src/target/statshouse /bin
 ENTRYPOINT ["/bin/statshouse"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,13 +8,15 @@ services:
     build:
       context: .
       dockerfile: build/statshouse-metadata.Dockerfile
+      args:
+        - BUILD_TRUSTED_SUBNET_GROUPS=0.0.0.0/0
     container_name: sh-metadata
-    command: --statshouse-addr=localhost:13337 --db-path=/var/lib/statshouse/metadata/db --binlog-prefix=/var/lib/statshouse/metadata/binlog/bl
+    user: "root:root"
+    command: --statshouse-addr=agent:13337 --db-path=/var/lib/statshouse/metadata/db --binlog-prefix=/var/lib/statshouse/metadata/binlog/bl
     volumes:
-      - metadata:/var/lib/statshouse
-    expose:
-      - 2442
-    network_mode: host
+      - metadata:/var/lib/statshouse/metadata
+    ports:
+      - "2442:2442"
   kh:
     profiles:
       - sh
@@ -27,15 +29,14 @@ services:
     hostname: aggregator
     volumes:
       - kh:/var/lib/clickhouse
-    expose:
-      - 8123
-      - 9000
+    ports:
+      - "8123:8123"
+      - "9000:9000"
     healthcheck:
       test: ["CMD-SHELL", "clickhouse-client --query='SELECT 1'"]
       interval: 200ms
       timeout: 1s
       retries: 1500
-    network_mode: host
   aggregator:
     profiles:
       - sh
@@ -43,11 +44,13 @@ services:
     build:
       context: .
       dockerfile: build/statshouse.Dockerfile
+      args:
+        - BUILD_TRUSTED_SUBNET_GROUPS=0.0.0.0/0
     container_name: sh-aggregator
-    command: aggregator --cluster=test_shard_localhost --log-level=trace --agg-addr=':13336' --kh=localhost:8123 --metadata-addr=localhost:2442 --auto-create --cache-dir=/var/lib/statshouse/cache/aggregator
-    expose:
-      - 13336
-    network_mode: host
+    user: "root:root"
+    command: aggregator -u=root -g=root --cluster=test_shard_aggregator --log-level=trace --agg-addr=':13336' --kh=kh:8123 --metadata-addr=metadata:2442 --auto-create --cache-dir=/var/lib/statshouse/cache/aggregator
+    ports:
+      - "13336:13336"
     depends_on:
       kh:
         condition: service_healthy
@@ -58,12 +61,15 @@ services:
     build:
       context: .
       dockerfile: build/statshouse.Dockerfile
+      args:
+        - BUILD_TRUSTED_SUBNET_GROUPS=0.0.0.0/0
     container_name: sh-agent
-    command: agent --cluster=test_shard_localhost --log-level=trace --agg-addr='localhost:13336,localhost:13336,localhost:13336' --cache-dir=/var/lib/statshouse/cache/agent --remote-write-enabled
+    user: "root:root"
+    command: agent -u=root -g=root --cluster=test_shard_aggregator --log-level=trace --agg-addr='aggregator:13336,aggregator:13336,aggregator:13336' --cache-dir=/var/lib/statshouse/cache/agent --remote-write-enabled
     expose:
       - 8081
-      - 13337/udp
-    network_mode: host
+    ports:
+      - "13337:13337/udp"
     depends_on:
       - aggregator
   api:
@@ -72,11 +78,13 @@ services:
     build:
       context: .
       dockerfile: build/statshouse-api.Dockerfile
+      args:
+        - BUILD_TRUSTED_SUBNET_GROUPS=0.0.0.0/0
     container_name: sh-api
-    command: --verbose --local-mode --access-log --clickhouse-v1-addrs= --clickhouse-v2-addrs=localhost:9000 --listen-addr=:10888 --metadata-addr=localhost:2442 --statshouse-addr=localhost:13337 --disk-cache=/var/lib/statshouse/cache/api/mapping_cache.sqlite3
-    expose:
-      - 10888
-    network_mode: host
+    user: "root:root"
+    command: --verbose --local-mode --access-log --clickhouse-v1-addrs= --clickhouse-v2-addrs=kh:9000 --listen-addr=:10888 --metadata-addr=metadata:2442 --statshouse-addr=agent:13337 --disk-cache=/var/lib/statshouse/cache/api/mapping_cache.sqlite3
+    ports:
+      - "10888:10888"
     depends_on:
       kh:
         condition: service_healthy
@@ -86,11 +94,17 @@ services:
     build:
       context: .
       dockerfile: build/all-in-one.Dockerfile
-    container_name: all-in-one
-    expose:
-      - 10888
-      - 13337/udp
-    network_mode: host
+    container_name: sh-all-in-one
+    user: "root:root"
+    ports:
+      - "2442:2442"
+      - "8123:8123"
+      - "10888:10888"
+      - "13336:13336"
+      - "13337:13337/udp"
+    volumes:
+      - metadata:/var/lib/statshouse/metadata
+      - kh:/var/lib/clickhouse
   grafana:
     profiles:
       - api-dev
@@ -109,9 +123,8 @@ services:
     volumes:
       - prometheus:/prometheus
       - ${PWD}/build/prometheus.yml:/etc/prometheus/prometheus.yml
-    expose:
-      - 9090
-    network_mode: host
+    ports:
+      - "9090:9090"
 
 volumes:
   kh:

--- a/localrun.sh
+++ b/localrun.sh
@@ -9,18 +9,23 @@ fi
 docker compose --profile "$PROFILE" up -d --build
 trap "{ docker compose --profile $PROFILE down; exit; }" exit
 echo -n Waiting for services to be ready...
-for c in kh all-in-one; do
+for c in kh sh-all-in-one; do
   if [ "$(docker container inspect -f '{{.State.Status}}' $c 2>/dev/null)" = "running" ]; then
     until docker exec $c clickhouse-client --query='SELECT 1' >/dev/null 2>&1; do echo -n .; sleep 0.2; done
+    until curl --output /dev/null --silent --head --fail http://localhost:8123/; do echo -n .; sleep 0.2; done
+    break
   fi
 done
-if [ "$(docker container inspect -f '{{.State.Status}}' sh-api 2>/dev/null)" = "running" ]; then
-  until curl --output /dev/null --silent --head --fail http://localhost:10888/; do echo -n .; sleep 0.2; done
-  URL="http://localhost:10888/view?live&f=-300&t=0&s=__contributors_log_rev"
-  case "$OSTYPE" in
-    darwin*)  open "$URL" ;;
-    linux*)   xdg-open "$URL" ;;
-  esac
-fi
+for c in sh-api sh-all-in-one; do
+  if [ "$(docker container inspect -f '{{.State.Status}}' $c 2>/dev/null)" = "running" ]; then
+    until curl --output /dev/null --silent --head --fail http://localhost:10888/; do echo -n .; sleep 0.2; done
+    URL="http://localhost:10888/view?live&f=-300&t=0&s=__contributors_log_rev"
+    case "$OSTYPE" in
+      darwin*)  open "$URL" ;;
+      linux*)   xdg-open "$URL" ;;
+    esac
+    break
+  fi
+done
 echo READY
 read -r -p "Press ENTER key or CTRL+C to exit."


### PR DESCRIPTION
* data persisted between runs
* to enable previous item all containers are run under root (not `kitten` as before)
* remove `network_mode: host`, use docker network
* add `-x` flag to `go mod download` to output progress
* ./localrun waits ClickHouse HTTP server up (to ensure ClickHouse is running)
* minor fixes