### PR TITLE
ui: make 'Auto (low)' level less noisy

### DIFF
--- a/statshouse-ui/src/store/statshouse.ts
+++ b/statshouse-ui/src/store/statshouse.ts
@@ -562,7 +562,7 @@ export const useStore = create<Store>()(
       ) {
         const agg =
           lastPlotParams.customAgg === -1
-            ? `${Math.floor(width / 2)}`
+            ? `${Math.floor(width / 4)}`
             : lastPlotParams.customAgg === 0
             ? `${Math.floor(width * devicePixelRatio)}`
             : `${lastPlotParams.customAgg}s`;


### PR DESCRIPTION
Too often it does not meaningfully differ from 'Auto'.