### PR TITLE
Rename "what" label

### DIFF
--- a/internal/promql/engine.go
+++ b/internal/promql/engine.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	labelWhat = "__what"
+	labelWhat = "__what__"
 )
 
 type Query struct {


### PR DESCRIPTION
Now `__what__`  (like `__name__` )