### PR TITLE
PromQL

### DIFF
--- a/internal/api/handler_promql.go
+++ b/internal/api/handler_promql.go
@@ -615,7 +615,7 @@ func getHandlerArgs(qry *promql.SeriesQuery, ai *accessInfo) (queryFn, string, p
 		}
 	}
 	for _, tagValue := range qry.SFilterIn {
-		filterIn[format.StringTopTagID] = append(filterIn[format.StringTopTagID], promqlEmptyToUnspecified(tagValue))
+		filterIn[format.StringTopTagID] = append(filterIn[format.StringTopTagID], promqlEncodeSTagValue(tagValue))
 		filterInM[format.StringTopTagID] = append(filterInM[format.StringTopTagID], tagValue)
 	}
 	var (
@@ -630,7 +630,7 @@ func getHandlerArgs(qry *promql.SeriesQuery, ai *accessInfo) (queryFn, string, p
 		}
 	}
 	for _, tagValue := range qry.SFilterOut {
-		filterOut[format.StringTopTagID] = append(filterOut[format.StringTopTagID], promqlEmptyToUnspecified(tagValue))
+		filterOut[format.StringTopTagID] = append(filterOut[format.StringTopTagID], promqlEncodeSTagValue(tagValue))
 		filterOutM[format.StringTopTagID] = append(filterOutM[format.StringTopTagID], tagValue)
 	}
 	// get "queryFn"
@@ -887,24 +887,17 @@ func getPromQuery(req getQueryReq) string {
 }
 
 func promqlGetFilterValue(tagID string, s string) string {
-	switch tagID {
-	case format.StringTopTagID:
-		return promqlUnspecifiedToEmpty(s)
+	switch {
+	case tagID == format.StringTopTagID && s == format.TagValueCodeZero:
+		return ""
 	default:
 		return s
 	}
 }
 
-func promqlEmptyToUnspecified(s string) string {
-	if s == "^$" {
-		return format.CodeTagValue(format.TagValueIDUnspecified)
-	}
-	return s
-}
-
-func promqlUnspecifiedToEmpty(s string) string {
-	if s == format.CodeTagValue(format.TagValueIDUnspecified) {
-		return "^$"
+func promqlEncodeSTagValue(s string) string {
+	if s == "" {
+		return format.TagValueCodeZero
 	}
 	return s
 }

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -24,7 +24,7 @@ const (
 	MaxStringLen = 128 // both for normal tags and _s, _h tags (string tops, hostnames)
 
 	tagValueCodePrefix     = " " // regular tag values can't start with whitespace
-	tagValueCodeZero       = tagValueCodePrefix + "0"
+	TagValueCodeZero       = tagValueCodePrefix + "0"
 	TagValueIDUnspecified  = 0
 	TagValueIDMappingFlood = -1
 
@@ -702,7 +702,7 @@ func bytePrint(c byte) bool {
 
 func CodeTagValue(code int32) string {
 	if code == 0 {
-		return tagValueCodeZero // fast-path with no allocations
+		return TagValueCodeZero // fast-path with no allocations
 	}
 	return tagValueCodePrefix + strconv.Itoa(int(code))
 }
@@ -766,7 +766,7 @@ func AddRawValuePrefix(s string) string {
 }
 
 func IsValueCodeZero(s string) bool {
-	return tagValueCodeZero == s
+	return TagValueCodeZero == s
 }
 
 func convertToValueComments(id2value map[int32]string) map[string]string {

--- a/internal/promql/engine.go
+++ b/internal/promql/engine.go
@@ -945,6 +945,9 @@ func (ev *evaluator) getTagValues(ctx context.Context, metric *format.MetricMeta
 }
 
 func (ev *evaluator) getTagValueID(metric *format.MetricMetaValue, tagX int, tagV string) (int32, error) {
+	if format.HasRawValuePrefix(tagV) {
+		return format.ParseCodeTagValue(tagV)
+	}
 	tag := metric.Tags[tagX]
 	if tag.Name == labels.BucketLabel && tag.Raw {
 		if v, err := strconv.ParseFloat(tagV, 32); err == nil {


### PR DESCRIPTION
* label filter starting with a space is treated as "raw" value
* convert " 0" string label filter to empty regexp string (was "^$" which is redundant, "" matches only empty string already)