### PR TITLE
PromQL

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1718,7 +1718,6 @@ func (h *Handler) handleGetQuery(ctx context.Context, debugQueries bool, req get
 	}
 
 	type testPromqlQuery struct {
-		key string
 		lod lodInfo
 	}
 	var (
@@ -1741,7 +1740,7 @@ func (h *Handler) handleGetQuery(ctx context.Context, debugQueries bool, req get
 				context.WithValue(ctx, accessInfoKey, &req.ai), // to check access rights when querying series
 				promqlExpr, version, from, to, now, width, widthKind, false, &promqlRand, nil,
 				func(version string, key string, pq any, lod any, avoidCache bool) {
-					promqlQueries = append(promqlQueries, testPromqlQuery{key, lod.(lodInfo)})
+					promqlQueries = append(promqlQueries, testPromqlQuery{lod.(lodInfo)})
 				})
 			return err
 		})
@@ -1845,7 +1844,7 @@ func (h *Handler) handleGetQuery(ctx context.Context, debugQueries bool, req get
 			shiftDelta := toSec(shift - oldestShift)
 			for lodIx, lod := range lods {
 				if testPromql {
-					seriesQueries = append(seriesQueries, testPromqlQuery{qs, lodInfo{
+					seriesQueries = append(seriesQueries, testPromqlQuery{lodInfo{
 						fromSec:   shiftTimestamp(lod.fromSec, lod.stepSec, shiftDelta, lod.location),
 						toSec:     shiftTimestamp(lod.toSec, lod.stepSec, shiftDelta, lod.location),
 						stepSec:   lod.stepSec,

--- a/internal/api/handler_promql.go
+++ b/internal/api/handler_promql.go
@@ -388,7 +388,11 @@ func (h *Handler) GetRichTagValue(qry promql.RichTagValueQuery) string {
 }
 
 func (h *Handler) GetTagValueID(v string) (int32, error) {
-	return h.getTagValueID(v)
+	res, err := h.getTagValueID(v)
+	if err != nil && httpCode(err) == http.StatusNotFound {
+		err = promql.ErrNotFound
+	}
+	return res, err
 }
 
 func (h *Handler) QuerySeries(ctx context.Context, qry *promql.SeriesQuery) (promql.SeriesBag, func(), error) {

--- a/internal/promql/engine.go
+++ b/internal/promql/engine.go
@@ -790,6 +790,9 @@ func (ev *evaluator) buildSeriesQuery(ctx context.Context, sel *parser.VectorSel
 			case labels.MatchEqual:
 				id, err := ev.getTagValueID(metric, i, matcher.Value)
 				if err != nil {
+					if err == ErrNotFound {
+						continue // ignore values with no mapping
+					}
 					return seriesQueryX{}, err
 				}
 				if metricH && !histogramQ.restore && matcher.Name == format.LETagName {
@@ -804,6 +807,9 @@ func (ev *evaluator) buildSeriesQuery(ctx context.Context, sel *parser.VectorSel
 			case labels.MatchNotEqual:
 				id, err := ev.getTagValueID(metric, i, matcher.Value)
 				if err != nil {
+					if err == ErrNotFound {
+						continue // ignore values with no mapping
+					}
 					return seriesQueryX{}, err
 				}
 				if metricH && !histogramQ.restore && matcher.Name == format.LETagName {

--- a/internal/promql/interface.go
+++ b/internal/promql/interface.go
@@ -8,6 +8,7 @@ package promql
 
 import (
 	"context"
+	"fmt"
 	"math"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -128,6 +129,8 @@ type TagValuesQuery struct {
 	Offset    int64
 	Options   Options
 }
+
+var ErrNotFound = fmt.Errorf("not found")
 
 type Handler interface {
 	//


### PR DESCRIPTION
* ignore values with no mapping
* don't compare cache query strings (make no sense because handler includes unmapped filter values in cache key but PromQL engine does not)