### PR TITLE
Gbuteyko/new historic conveyor

### DIFF
--- a/internal/agent/agent_loaders.go
+++ b/internal/agent/agent_loaders.go
@@ -34,6 +34,10 @@ func GetConfig(network string, rpcClient *rpc.Client, addressesExt []string, isE
 		addr := addresses[nextAddr]
 		dst, err := clientGetConfig(network, rpcClient, addr, isEnvStaging, componentTag, archTag, cluster)
 		if err == nil {
+			// when running agent from outside run_local docker
+			// for i := range dst.Addresses {
+			//	dst.Addresses[i] = strings.ReplaceAll(dst.Addresses[i], "aggregator", "localhost")
+			// }
 			logF("Configuration: success autoconfiguration from (%q), address list is (%q), max is %d", strings.Join(addresses, ","), strings.Join(dst.Addresses, ","), dst.MaxAddressesCount)
 			return dst
 		}

--- a/internal/aggregator/aggregator.go
+++ b/internal/aggregator/aggregator.go
@@ -432,10 +432,6 @@ func selectShardReplicaImpl(httpClient *http.Client, khAddr string, cluster stri
 	return 0, 0, nil, fmt.Errorf("HTTP get from clickhouse %q for cluster %q returned body with no local replicas - %q", khAddr, cluster, string(body))
 }
 
-func (a *Aggregator) sendBucket(rnd *rand.Rand, bodyStorage *[]byte, httpClient *http.Client, b *aggregatorBucket, historic bool, comment string) (status int, exception int, dur float64, err error) {
-	return status, exception, dur, err
-}
-
 func (a *Aggregator) goSend(senderID int) {
 	rnd := rand.New()
 	httpClient := makeHTTPClient(data_model.ClickHouseTimeout)

--- a/internal/aggregator/aggregator_handlers.go
+++ b/internal/aggregator/aggregator_handlers.go
@@ -280,9 +280,6 @@ func (a *Aggregator) handleClientBucket2(_ context.Context, hctx *rpc.HandlerCon
 			if aggBucket == nil {
 				aggBucket = &aggregatorBucket{time: args.Time}
 				a.historicBuckets[args.Time] = aggBucket
-				if a.sendHistoricCondition() {
-					a.cond.Broadcast() // we are not sure that Signal is enough
-				}
 			}
 		} else {
 			// If source receives error from recent conveyor quickly, it will come to spare while bucket is still recent

--- a/internal/aggregator/aggregator_log.go
+++ b/internal/aggregator/aggregator_log.go
@@ -63,13 +63,14 @@ func (a *Aggregator) goInternalLog() {
 	}
 }
 
-func (a *Aggregator) reporInsert(bucketTime uint32, conveyorTag int32, err error, status int, exception int, dur float64, bodySize int) {
-	key := data_model.AggKey(bucketTime, format.BuiltinMetricIDAggInsertTime,
-		[16]int32{0, 0, 0, 0, conveyorTag, format.TagValueIDInsertTimeOK, int32(status), int32(exception)}, a.aggregatorHost, a.shardKey, a.replicaKey)
+func (a *Aggregator) reportInsertKeys(bucketTime uint32, metric int32, historic bool, err error, status int, exception int) data_model.Key {
+	key := data_model.AggKey(bucketTime, metric,
+		[16]int32{0, 0, 0, 0, format.TagValueIDConveyorRecent, format.TagValueIDInsertTimeOK, int32(status), int32(exception)}, a.aggregatorHost, a.shardKey, a.replicaKey)
 	if err != nil {
 		key.Keys[5] = format.TagValueIDInsertTimeError
 	}
-	a.sh2.AddValueCounterHost(key, dur, 1, 0)
-	a.sh2.AddValueCounterHost(data_model.Key{Timestamp: 0, Metric: format.BuiltinMetricIDAggInsertTimeReal, Keys: key.Keys}, dur, 1, 0)
-	a.sh2.AddValueCounterHost(data_model.Key{Timestamp: 0, Metric: format.BuiltinMetricIDAggInsertSizeReal, Keys: key.Keys}, float64(bodySize), 1, 0)
+	if historic {
+		key.Keys[4] = format.TagValueIDConveyorHistoric
+	}
+	return key
 }

--- a/internal/aggregator/config.go
+++ b/internal/aggregator/config.go
@@ -89,6 +89,9 @@ func ValidateConfigAggregator(c ConfigAggregator) error {
 	if c.HistoricInserters < 1 {
 		return fmt.Errorf("--historic-inserters (%d) must be >= 1", c.HistoricInserters)
 	}
+	if c.HistoricInserters > 4 { // Otherwise batching during historic inserts will become too small
+		return fmt.Errorf("--historic-inserters (%d) must be <= 4", c.HistoricInserters)
+	}
 
 	if c.StringTopCountInsert < data_model.MinStringTopInsert {
 		return fmt.Errorf("--string-top-insert (%d) must be >= %d", c.StringTopCountInsert, data_model.MinStringTopInsert)

--- a/internal/data_model/constants.go
+++ b/internal/data_model/constants.go
@@ -26,16 +26,8 @@ const (
 	AggregationShardsPerSecond    = 1 << LogAggregationShardsPerSecond
 
 	MaxHistorySendStreams = 24 // Do not change, unless you understand how exactly new conveyor works.
-	// [a, b, c, d, e, f, g, h, i, j]               <- this is 10 seconds sent by agent
-	//                [f, g, h, i, j]               <- after [a, b, c, d, e] is taken by insert historic, this is what remains
-	//                             []               <- after [a, b, c, d, e] is inserted and replies sent, [f, g, h, i, j] are taken
-	//                             [k, l, m, n, o]  <- while [f, g, h, i, j] are being inserted, agent receives replies to [a, b, c, d, e] and sents next [k, l, m, n, o]
-	// So, we have enough seconds always to perform smooth rolling insert.
-	// Each historic second in the diagram above actually consists of data sent by multiple agents.
-	// In the worst case, amount of memory is approx. MaxHistorySendStreams * agent insert budget per shard
 	// Big TODO - using feedback increase the length of this queue in a way it is close to some total memory limit.
 	// So if there is single agent with many seconds, queue would grow dramatically (thousand seconds)
-	MaxHistoryInsertBatch = 12 // Should be <= MaxHistorySendStreams/2 if we have 1 historic inserter, and /3 if we have 2,
 	// so that we have enough historic buckets waiting when we finish previous insert
 	MaxHistoryInsertContributorsScale = 4 // We will batch less several historic buckets if they contain many contributors
 

--- a/internal/pcache/cache_test.go
+++ b/internal/pcache/cache_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.uber.org/atomic"
 )
 


### PR DESCRIPTION
Historic conveyor now appends historic buckets to recent bucket during recent insert, thus making 0 additional insert requests to clickhouse.

With default settings historic insert speed is
* 12x real time when # of agents with historic seconds is low.
*   4x real time when all agents have historic seconds
