### PR TITLE
Restore pprof legacy command line parameters

### DIFF
--- a/cmd/statshouse-api/statshouse-api.go
+++ b/cmd/statshouse-api/statshouse-api.go
@@ -80,6 +80,7 @@ type args struct {
 	listenRPCAddr            string
 	localMode                bool
 	pidFile                  string
+	pprofAddr                string
 	pprofHTTP                bool
 	protectedMetricPrefixes  []string
 	showInvisible            bool
@@ -136,6 +137,7 @@ func main() {
 	pflag.BoolVar(&argv.insecureMode, "insecure-mode", false, "set insecure-mode if you don't need any access verification")
 	pflag.StringVar(&argv.pidFile, "pid-file", "statshouse_api.pid", "path to PID file") // fpr table flip
 
+	pflag.StringVar(&argv.pprofAddr, "pprof-addr", "", "Go pprof HTTP listen address (deprecated)")
 	pflag.BoolVar(&argv.pprofHTTP, "pprof-http", true, "Serve Go pprof HTTP on RPC port")
 	pflag.StringSliceVar(&argv.protectedMetricPrefixes, "protected-metric-prefixes", nil, "comma-separated list of metric prefixes that require access bits set")
 	pflag.BoolVar(&argv.showInvisible, "show-invisible", false, "show invisible metrics as well")

--- a/cmd/statshouse/argv.go
+++ b/cmd/statshouse/argv.go
@@ -30,15 +30,16 @@ const (
 var (
 	argv struct {
 		// common
-		logFile        string
-		logLevel       string
-		userLogin      string // логин для setuid
-		userGroup      string // логин для setguid
-		maxOpenFiles   uint64
-		pprofHTTP      bool
-		aesPwdFile     string
-		cacheDir       string // different default
-		customHostName string // useful for testing and in some environments
+		logFile         string
+		logLevel        string
+		userLogin       string // логин для setuid
+		userGroup       string // логин для setguid
+		maxOpenFiles    uint64
+		pprofListenAddr string
+		pprofHTTP       bool
+		aesPwdFile      string
+		cacheDir        string // different default
+		customHostName  string // useful for testing and in some environments
 
 		aggAddr string // common, different meaning
 
@@ -107,6 +108,7 @@ func argvAddCommonFlags() {
 	flag.StringVar(&argv.userLogin, "u", defaultUser, "sets user name to make setuid")
 	flag.StringVar(&argv.userGroup, "g", defaultGroup, "sets user group to make setguid")
 
+	flag.StringVar(&argv.pprofListenAddr, "pprof", "", "HTTP pprof listen address (deprecated)")
 	flag.BoolVar(&argv.pprofHTTP, "pprof-http", true, "Serve Go pprof HTTP on RPC port")
 
 	flag.StringVar(&argv.cacheDir, "cache-dir", "", "Data that cannot be immediately sent will be stored here together with metric metadata cache.")


### PR DESCRIPTION
need to drop them on servers first