### PR TITLE
Autocreate specifies all tags as UI does

### DIFF
--- a/internal/aggregator/autocreate.go
+++ b/internal/aggregator/autocreate.go
@@ -130,7 +130,7 @@ func (ac *autoCreate) createMetric(args tlstatshouse.AutoCreate) error {
 	} else {
 		value = format.MetricMetaValue{
 			Name:       args.Metric,
-			Tags:       []format.MetricMetaTag{{}},
+			Tags:       make([]format.MetricMetaTag, format.MaxTags),
 			Visible:    true,
 			Kind:       args.Kind,
 			Resolution: 1,


### PR DESCRIPTION
otherwise tags aren't visible in UI by default