### PR TITLE
[sqlite] add ErrBrokenEngine

### DIFF
--- a/internal/sqlite/conn.go
+++ b/internal/sqlite/conn.go
@@ -61,9 +61,12 @@ func (c *sqliteConn) startNewConn(autoSavepoint bool, ctx context.Context, stats
 }
 
 func (c *sqliteConn) startNewROConn(ctx context.Context, stats *StatsOptions) (Conn, error) {
-	var err error
 	c.mu.Lock()
-	err = c.rw.Exec("BEGIN")
+	if c.err != nil {
+		c.mu.Unlock()
+		return Conn{}, c.err
+	}
+	err := c.rw.Exec("BEGIN")
 	if err != nil {
 		c.mu.Unlock()
 		return Conn{}, err

--- a/internal/sqlite/engine_race_test.go
+++ b/internal/sqlite/engine_race_test.go
@@ -1,0 +1,175 @@
+package sqlite
+
+import (
+	"context"
+	"reflect"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rand"
+)
+
+func Test_Engine_Do(t *testing.T) {
+	dir := t.TempDir()
+	engine, _ := openEngine(t, dir, "db", schema, true, false, false, false, WaitCommit, nil)
+	agg := &testAggregation{}
+	n := 32
+	iters := 1000
+	wg := &sync.WaitGroup{}
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				data := make([]byte, 20)
+				_, err := rand.Read(data)
+				require.NoError(t, err)
+				data = strconv.AppendInt(data, int64(i), 10)
+				data = strconv.AppendInt(data, int64(j), 10)
+
+				str := string(data)
+				err = insertText(engine, str, j%10 == 0)
+				if err == errTest {
+					continue
+				}
+				require.NoError(t, err)
+				agg.mx.Lock()
+				agg.writeHistory = append(agg.writeHistory, str)
+				agg.mx.Unlock()
+			}
+		}(i)
+	}
+	wg.Wait()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	require.NoError(t, engine.Close(ctx))
+	engine, _ = openEngine(t, dir, "db", schema, false, false, false, false, WaitCommit, func(s string) {
+		t.Fatal("mustn't apply music")
+	})
+	expectedMap := map[string]struct{}{}
+	for _, t := range agg.writeHistory {
+		expectedMap[t] = struct{}{}
+	}
+	actualDb := map[string]struct{}{}
+	err := engine.Do(context.Background(), "test", func(conn Conn, bytes []byte) ([]byte, error) {
+		rows := conn.Query("test", "SELECT t from test_db")
+		if rows.err != nil {
+			return bytes, rows.err
+		}
+		for rows.Next() {
+			t, err := rows.ColumnBlobString(0)
+			if err != nil {
+				return bytes, err
+			}
+			actualDb[t] = struct{}{}
+		}
+		return bytes, nil
+	})
+	require.NoError(t, err)
+	require.True(t, reflect.DeepEqual(expectedMap, actualDb))
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	require.NoError(t, engine.Close(ctx))
+}
+
+func Test_Engine_View(t *testing.T) {
+	dir := t.TempDir()
+	engine, _ := openEngine(t, dir, "db", schema, true, false, false, false, WaitCommit, nil)
+	agg := &testAggregation{}
+	iters := 1000
+	for j := 0; j < iters; j++ {
+		data := make([]byte, 20)
+		_, err := rand.Read(data)
+		require.NoError(t, err)
+		data = strconv.AppendInt(data, int64(j), 10)
+
+		str := string(data)
+		err = insertText(engine, str, false)
+		if err == errTest {
+			continue
+		}
+		require.NoError(t, err)
+		agg.mx.Lock()
+		agg.writeHistory = append(agg.writeHistory, str)
+		agg.mx.Unlock()
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	require.NoError(t, engine.Close(ctx))
+	engine, _ = openEngine(t, dir, "db", schema, false, false, false, false, WaitCommit, func(s string) {
+		t.Fatal("mustn't apply music")
+	})
+	expectedMap := map[string]struct{}{}
+	for _, t := range agg.writeHistory {
+		expectedMap[t] = struct{}{}
+	}
+	wg := &sync.WaitGroup{}
+	n := 32
+	iters = 100
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				err := engine.View(context.Background(), "test", func(conn Conn) error {
+					actualDb := map[string]struct{}{}
+					rows := conn.Query("test", "SELECT t from test_db")
+					if rows.err != nil {
+						return rows.err
+					}
+					for rows.Next() {
+						t, err := rows.ColumnBlobString(0)
+						if err != nil {
+							return err
+						}
+						actualDb[t] = struct{}{}
+					}
+					require.True(t, reflect.DeepEqual(expectedMap, actualDb))
+					return nil
+				})
+				require.NoError(t, err)
+			}
+		}()
+	}
+	wg.Wait()
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	require.NoError(t, engine.Close(ctx))
+}
+
+func Test_ReadAndExit(t *testing.T) {
+	const n = 1000
+	dir := t.TempDir()
+	engineMaster, _ := openEngine(t, dir, "db", schema, true, false, false, false, NoWaitCommit, nil)
+	wg := sync.WaitGroup{}
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			err := insertText(engineMaster, strconv.Itoa(i), false)
+			require.NoError(t, err)
+		}(i)
+	}
+	wg.Wait()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	require.NoError(t, engineMaster.Close(ctx))
+	engineMaster, _ = openEngine(t, dir, "db1", schema, false, false, true, false, NoBinlog, nil)
+	c := 0
+	err := engineMaster.Do(context.Background(), "test", func(conn Conn, cache []byte) ([]byte, error) {
+		rows := conn.Query("test", "SELECT t from test_db")
+		for rows.Next() {
+			c++
+		}
+		return cache, nil
+	})
+	require.NoError(t, err)
+	require.Greater(t, c, 0, "no data in replica")
+	require.Equal(t, c, n)
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	require.NoError(t, engineMaster.Close(ctx))
+}

--- a/internal/sqlite/engine_test.go
+++ b/internal/sqlite/engine_test.go
@@ -273,69 +273,6 @@ func Test_Engine_Reread_From_Random_Place(t *testing.T) {
 	require.NoError(t, engine.Close(ctx))
 }
 
-func Test_Engine(t *testing.T) {
-	dir := t.TempDir()
-	engine, _ := openEngine(t, dir, "db", schema, true, false, false, false, WaitCommit, nil)
-	agg := &testAggregation{}
-	n := 32
-	iters := 1000
-	wg := &sync.WaitGroup{}
-	for i := 0; i < n; i++ {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
-			for j := 0; j < iters; j++ {
-				data := make([]byte, 20)
-				_, err := rand.Read(data)
-				require.NoError(t, err)
-				data = strconv.AppendInt(data, int64(i), 10)
-				data = strconv.AppendInt(data, int64(j), 10)
-
-				str := string(data)
-				err = insertText(engine, str, j%10 == 0)
-				if err == errTest {
-					continue
-				}
-				require.NoError(t, err)
-				agg.mx.Lock()
-				agg.writeHistory = append(agg.writeHistory, str)
-				agg.mx.Unlock()
-			}
-		}(i)
-	}
-	wg.Wait()
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-	require.NoError(t, engine.Close(ctx))
-	engine, _ = openEngine(t, dir, "db", schema, false, false, false, false, WaitCommit, func(s string) {
-		t.Fatal("mustn't apply music")
-	})
-	expectedMap := map[string]struct{}{}
-	for _, t := range agg.writeHistory {
-		expectedMap[t] = struct{}{}
-	}
-	actualDb := map[string]struct{}{}
-	err := engine.Do(context.Background(), "test", func(conn Conn, bytes []byte) ([]byte, error) {
-		rows := conn.Query("test", "SELECT t from test_db")
-		if rows.err != nil {
-			return bytes, rows.err
-		}
-		for rows.Next() {
-			t, err := rows.ColumnBlobString(0)
-			if err != nil {
-				return bytes, err
-			}
-			actualDb[t] = struct{}{}
-		}
-		return bytes, nil
-	})
-	require.NoError(t, err)
-	require.True(t, reflect.DeepEqual(expectedMap, actualDb))
-	ctx, cancel = context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-	require.NoError(t, engine.Close(ctx))
-}
-
 func Test_Engine_Read_Empty_Raw(t *testing.T) {
 	schema := "CREATE TABLE IF NOT EXISTS test_db (id INTEGER PRIMARY KEY AUTOINCREMENT, oid INT, data TEXT);"
 	dir := t.TempDir()
@@ -568,40 +505,6 @@ func Test_Engine_Put_And_Read_RO(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 	require.NoError(t, engine.Close(ctx))
-}
-
-func Test_ReadAndExit(t *testing.T) {
-	const n = 1000
-	dir := t.TempDir()
-	engineMaster, _ := openEngine(t, dir, "db", schema, true, false, false, false, NoWaitCommit, nil)
-	wg := sync.WaitGroup{}
-	for i := 0; i < n; i++ {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
-			err := insertText(engineMaster, strconv.Itoa(i), false)
-			require.NoError(t, err)
-		}(i)
-	}
-	wg.Wait()
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-	require.NoError(t, engineMaster.Close(ctx))
-	engineMaster, _ = openEngine(t, dir, "db1", schema, false, false, true, false, NoBinlog, nil)
-	c := 0
-	err := engineMaster.Do(context.Background(), "test", func(conn Conn, cache []byte) ([]byte, error) {
-		rows := conn.Query("test", "SELECT t from test_db")
-		for rows.Next() {
-			c++
-		}
-		return cache, nil
-	})
-	require.NoError(t, err)
-	require.Greater(t, c, 0, "no data in replica")
-	require.Equal(t, c, n)
-	ctx, cancel = context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-	require.NoError(t, engineMaster.Close(ctx))
 }
 
 func Test_Engine_Slice_Params(t *testing.T) {

--- a/internal/sqlite/errors.go
+++ b/internal/sqlite/errors.go
@@ -1,0 +1,14 @@
+package sqlite
+
+import "errors"
+
+var (
+	errAlreadyClosed = errors.New("sqlite-engine: already closed")
+	errUnsafe        = errors.New("sqlite-engine: unsafe SQL")
+	ErrReadOnly      = errors.New("sqlite-engine: engine is readonly")
+	ErrEngineBroken  = errors.New("sqlite-engine: engine is broken")
+)
+
+func IsEngineBrokenError(err error) bool {
+	return err == ErrEngineBroken || errors.Is(err, ErrEngineBroken)
+}


### PR DESCRIPTION
Если движок пришел в неконсистентное состояние, write запросы больше не могут обрабатываться.

В этом случае вернем специальную ошибку чтобы навесить на нее Алерты (при этом сам движок может работать в режиме чтения и обрабатывать read нагрузку.