### PR TITLE
PromQL: fixed grouping

### DIFF
--- a/internal/promql/engine.go
+++ b/internal/promql/engine.go
@@ -695,6 +695,8 @@ func (ev *evaluator) evalBinary(expr *parser.BinaryExpr) ([]Series, error) {
 			}
 			var rhsM map[uint64]int
 			rhsM, err = rhs.hash(ev, hashOptions{
+				on:    expr.VectorMatching.On,
+				tags:  expr.VectorMatching.MatchingLabels,
 				stags: lhs.Meta.STags,
 			})
 			if err != nil {
@@ -720,6 +722,8 @@ func (ev *evaluator) evalBinary(expr *parser.BinaryExpr) ([]Series, error) {
 		case parser.CardOneToMany:
 			var lhsM map[uint64]int
 			lhsM, err = lhs.hash(ev, hashOptions{
+				on:    expr.VectorMatching.On,
+				tags:  expr.VectorMatching.MatchingLabels,
 				stags: rhs.Meta.STags,
 			})
 			if err != nil {
@@ -727,8 +731,8 @@ func (ev *evaluator) evalBinary(expr *parser.BinaryExpr) ([]Series, error) {
 			}
 			var rhsG []seriesGroup
 			rhsG, err = rhs.group(ev, hashOptions{
-				tags:  expr.VectorMatching.MatchingLabels,
 				on:    expr.VectorMatching.On,
+				tags:  expr.VectorMatching.MatchingLabels,
 				stags: lhs.Meta.STags,
 			})
 			if err != nil {


### PR DESCRIPTION
implicitly ignore "__name__" tag when applying binary operation with "ignore" modifier