### PR TITLE
stats: add klog

### DIFF
--- a/internal/format/builtin.go
+++ b/internal/format/builtin.go
@@ -311,6 +311,7 @@ const (
 	TagValueIDSystemMetricSocksStat = 6
 	TagValueIDSystemMetricProtocols = 7
 	TagValueIDSystemMetricVMStat    = 8
+	TagValueIDSystemMetricDMesgStat = 9
 
 	TagValueIDRPC  = 1
 	TagValueIDHTTP = 2
@@ -1453,6 +1454,7 @@ Value is delta between second value and time it was inserted.`,
 					TagValueIDSystemMetricSocksStat: "socks",
 					TagValueIDSystemMetricProtocols: "protocols",
 					TagValueIDSystemMetricVMStat:    "vmstat",
+					TagValueIDSystemMetricDMesgStat: "dmesg",
 				}),
 			}},
 		},

--- a/internal/format/builtin.go
+++ b/internal/format/builtin.go
@@ -323,6 +323,8 @@ const (
 
 	TagValueIDSamplingDecisionKeep    = -1
 	TagValueIDSamplingDecisionDiscard = -2
+
+	TagValueIDDMESGParseError = 1
 )
 
 var (
@@ -1606,7 +1608,13 @@ Value is delta between second value and time it was inserted.`,
 			Kind:        MetricKindCounter,
 			Description: `Always empty metric because SH don't have errors'`,
 			Tags: []MetricMetaTag{
-				{Description: "environment"}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}},
+				{Description: "environment"}, {
+					Description: "error_type",
+					Raw:         true,
+					ValueComments: convertToValueComments(map[int32]string{
+						TagValueIDDMESGParseError: "dmesg_parse",
+					}),
+				}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}},
 		},
 	}
 

--- a/internal/format/predefined_hardware.go
+++ b/internal/format/predefined_hardware.go
@@ -32,6 +32,7 @@ const (
 	BuiltinMetricIDOOMKill         = -1030
 	BuiltinMetricIDNumaEvents      = -1031
 	BuiltinMetricIDDMesgEvents     = -1032
+	BuiltinMetricIDOOMKillDetailed = -1033
 
 	BuiltinMetricNameCpuUsage      = "host_cpu_usage"
 	BuiltinMetricNameSoftIRQ       = "host_softirq"
@@ -68,11 +69,12 @@ const (
 	BuiltinMetricNameTCPSocketMemory = "host_tcp_socket_memory"
 	BuiltinMetricNameSocketUsedv2    = "host_socket_used"
 
-	BuiltinMetricNamePageFault   = "host_page_fault"
-	BuiltinMetricNamePagedMemory = "host_paged_memory"
-	BuiltinMetricNameOOMKill     = "host_oom_kill"
-	BuiltinMetricNameNumaEvents  = "host_numa_events"
-	BuiltinMetricNameDMesgEvents = "host_dmesg_events"
+	BuiltinMetricNamePageFault       = "host_page_fault"
+	BuiltinMetricNamePagedMemory     = "host_paged_memory"
+	BuiltinMetricNameOOMKill         = "host_oom_kill"
+	BuiltinMetricNameNumaEvents      = "host_numa_events"
+	BuiltinMetricNameDMesgEvents     = "host_dmesg_events"
+	BuiltinMetricNameOOMKillDetailed = "host_oom_kill_detailed"
 
 	RawIDTagNice      = 1
 	RawIDTagSystem    = 2
@@ -623,6 +625,15 @@ var hostMetrics = map[int32]*MetricMetaValue{
 		Name:        BuiltinMetricNameOOMKill,
 		Kind:        MetricKindCounter,
 		Description: "The number of OOM",
+	},
+	BuiltinMetricIDOOMKillDetailed: {
+		Name:        BuiltinMetricNameOOMKillDetailed,
+		Kind:        MetricKindCounter,
+		Description: "The number of OOM",
+		Tags: []MetricMetaTag{
+			{
+				Description: "process",
+			}},
 	},
 	BuiltinMetricIDPageFault: {
 		Name:        BuiltinMetricNamePageFault,

--- a/internal/format/predefined_hardware.go
+++ b/internal/format/predefined_hardware.go
@@ -31,6 +31,7 @@ const (
 	BuiltinMetricIDPagedMemory     = -1029
 	BuiltinMetricIDOOMKill         = -1030
 	BuiltinMetricIDNumaEvents      = -1031
+	BuiltinMetricIDDMesgEvents     = -1032
 
 	BuiltinMetricNameCpuUsage      = "host_cpu_usage"
 	BuiltinMetricNameSoftIRQ       = "host_softirq"
@@ -71,6 +72,7 @@ const (
 	BuiltinMetricNamePagedMemory = "host_paged_memory"
 	BuiltinMetricNameOOMKill     = "host_oom_kill"
 	BuiltinMetricNameNumaEvents  = "host_numa_events"
+	BuiltinMetricNameDMesgEvents = "host_dmesg_events"
 
 	RawIDTagNice      = 1
 	RawIDTagSystem    = 2
@@ -160,6 +162,30 @@ const (
 	RawIDTagHintFaults      = 7
 	RawIDTagHintFaultsLocal = 8
 	RawIDTagPagesMigrated   = 9
+
+	// based on sys/syslog.h
+	RawIDTag_Emerg  = 0
+	RawIDTag_Alert  = 1
+	RawIDTag_Crit   = 2
+	RawIDTag_Err    = 3
+	RawIDTag_Warn   = 4
+	RawIDTag_Notice = 5
+	RawIDTag_Info   = 6
+	RawIDTag_Debug  = 7
+
+	RawIDTag_kern     = 0
+	RawIDTag_user     = 1
+	RawIDTag_mail     = 2
+	RawIDTag_daemon   = 3
+	RawIDTag_auth     = 4
+	RawIDTag_syslog   = 5
+	RawIDTag_lpr      = 6
+	RawIDTag_news     = 7
+	RawIDTag_uucp     = 8
+	RawIDTag_cron     = 9
+	RawIDTag_authpriv = 10
+	RawIDTag_ftp      = 11
+
 	// don't use key tags greater than 11. 12..15 reserved by builtin metrics
 	HostDCTag = 11
 )
@@ -628,7 +654,7 @@ var hostMetrics = map[int32]*MetricMetaValue{
 			}},
 	},
 	BuiltinMetricIDNumaEvents: {
-		Name:        BuiltinMetricNamePagedMemory,
+		Name:        BuiltinMetricNameNumaEvents,
 		Kind:        MetricKindCounter,
 		Description: "NUMA events",
 		Tags: []MetricMetaTag{
@@ -647,5 +673,43 @@ var hostMetrics = map[int32]*MetricMetaValue{
 					RawIDTagPagesMigrated:   "pages_migrated",
 				}),
 			}},
+	},
+	BuiltinMetricIDDMesgEvents: {
+		Name:        BuiltinMetricNameDMesgEvents,
+		Kind:        MetricKindCounter,
+		Description: "dmesg events",
+		Tags: []MetricMetaTag{
+			{
+				Description: "facility",
+				Raw:         true,
+				ValueComments: convertToValueComments(map[int32]string{
+					RawIDTag_kern:     "kern",
+					RawIDTag_user:     "user",
+					RawIDTag_mail:     "mail",
+					RawIDTag_daemon:   "daemon",
+					RawIDTag_auth:     "auth",
+					RawIDTag_syslog:   "syslog",
+					RawIDTag_lpr:      "lpr",
+					RawIDTag_news:     "news",
+					RawIDTag_uucp:     "uucp",
+					RawIDTag_cron:     "crom",
+					RawIDTag_authpriv: "authpriv",
+					RawIDTag_ftp:      "ftp",
+				}),
+			},
+			{
+				Description: "level",
+				Raw:         true,
+				ValueComments: convertToValueComments(map[int32]string{
+					RawIDTag_Emerg:  "emerg",
+					RawIDTag_Alert:  "alert",
+					RawIDTag_Crit:   "crit",
+					RawIDTag_Err:    "err",
+					RawIDTag_Warn:   "warn",
+					RawIDTag_Notice: "notice",
+					RawIDTag_Info:   "info",
+					RawIDTag_Debug:  "debug",
+				})},
+		},
 	},
 }

--- a/internal/stats/dmesg_common.go
+++ b/internal/stats/dmesg_common.go
@@ -1,0 +1,221 @@
+package stats
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/vkcom/statshouse/internal/format"
+	"go4.org/mem"
+	"golang.org/x/exp/slices"
+)
+
+const (
+	SYSLOG_ACTION_READ_ALL    = 3
+	SYSLOG_ACTION_SIZE_BUFFER = 10
+)
+
+type (
+	DMesgStats struct {
+		lastTS   timestamp
+		pushStat bool
+		writer   MetricWriter
+		parser   *parser
+	}
+	parser struct {
+		cache []byte
+		body  []byte
+		err   error
+	}
+
+	timestamp struct {
+		sec  int64
+		usec int64
+	}
+
+	klogMsg struct {
+		level    int32
+		facility int32
+		ts       timestamp
+		msgtype  string
+		msg      string
+	}
+)
+
+func (c *DMesgStats) Skip() bool {
+	return false
+}
+
+func (*DMesgStats) Name() string {
+	return "cpu_stats"
+}
+
+func (c *DMesgStats) PushDuration(now int64, d time.Duration) {
+	c.writer.WriteSystemMetricValueWithoutHost(now, format.BuiltinMetricNameSystemMetricScrapeDuration, d.Seconds(), format.TagValueIDSystemMetricCPU)
+}
+
+func NewDMesgStats(writer MetricWriter) (*DMesgStats, error) {
+	return &DMesgStats{writer: writer}, nil
+}
+
+const (
+	LOG_FACMASK = 0x03f8
+	LOG_PRIMASK = 0x07
+)
+
+func log_fac(p int32) int32 {
+	return ((p) & LOG_FACMASK) >> 3
+}
+
+func log_pri(p int32) int32 {
+	return (p) & LOG_PRIMASK
+}
+
+func leOrEq(a, b timestamp) bool {
+	if a.sec < b.sec {
+		return true
+	}
+	if a.sec > b.sec {
+		return false
+	}
+	return a.usec <= b.usec
+}
+
+func (c *DMesgStats) handleMsg(nowUnix int64, klog klogMsg) {
+	// don't use event ts to avoid historic conveyor
+	c.writer.WriteSystemMetricCount(nowUnix, format.BuiltinMetricNameDMesgEvents, 1, klog.facility, klog.level)
+}
+
+func (c *DMesgStats) handleMsgs(nowUnix int64, klog []byte, pushStat bool) error {
+	c.parser.body = klog
+	p := c.parser
+	lastTS := c.lastTS
+	for p.hasTail() {
+		p.mustChar('<')
+		if p.err != nil {
+			return p.err
+		}
+		levFac := p.parseNumber()
+		if p.err != nil {
+			return p.err
+		}
+		lev, fac := extractLevFac(int32(levFac))
+		p.mustChar('>')
+		if p.err != nil {
+			return p.err
+		}
+		p.mustChar('[')
+		if p.err != nil {
+			return p.err
+		}
+		sec := p.parseNumber()
+		p.mustChar('.')
+		if p.err != nil {
+			return p.err
+		}
+		usec := p.parseNumber()
+		if p.err != nil {
+			return p.err
+		}
+		p.mustChar(']')
+		p.mustChar(' ')
+		if p.err != nil {
+			return p.err
+		}
+		_ = p.parseUntil(':')
+		if p.err != nil {
+			return p.err
+		}
+		_ = p.parseUntil('\n')
+		if p.err != nil {
+			return p.err
+		}
+		klog := klogMsg{
+			level:    lev,
+			facility: fac,
+			ts:       timestamp{sec: sec, usec: usec},
+			msgtype:  "",
+			msg:      "",
+		}
+		if leOrEq(klog.ts, lastTS) {
+			continue
+		}
+		if pushStat {
+			c.handleMsg(nowUnix, klog)
+		}
+		c.lastTS = klog.ts
+	}
+	return nil
+}
+
+func extractLevFac(levFac int32) (lev int32, fac int32) {
+	return log_pri(levFac), log_fac(levFac)
+}
+
+func (p *parser) hasTail() bool {
+	return p.err == nil && len(p.body) > 0
+}
+
+func (p *parser) skipN(n int) {
+	p.body = p.body[n:]
+
+}
+
+func (p *parser) mustChar(ch byte) {
+	if p.body[0] == ch {
+		p.skipN(1)
+		return
+	}
+	p.err = fmt.Errorf("expect %s", string(rune(ch)))
+}
+
+func (p *parser) mustSequence(bs []byte) []byte {
+	cache := p.cache[:0]
+	for {
+		b, err := p.checkChar()
+		if err != nil {
+			break
+		}
+		if slices.Contains(bs, b) {
+			p.skipN(1)
+		} else {
+			break
+		}
+		cache = append(cache, b)
+	}
+	if len(cache) == 0 {
+		p.err = fmt.Errorf("mustSequence error: %s", bs)
+	}
+	return cache
+}
+
+func (p *parser) checkChar() (byte, error) {
+	if !p.hasTail() {
+		return 0, io.ErrUnexpectedEOF
+	}
+	b := p.body[0]
+	return b, nil
+}
+
+var numbers = []byte{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}
+
+func (p *parser) parseNumber() int64 {
+	seq := p.mustSequence(numbers)
+	n, err := mem.ParseInt(mem.B(seq), 10, 64)
+	if err != nil {
+		panic(err)
+	}
+	return n
+}
+
+func (p *parser) parseUntil(b byte) []byte {
+	i := mem.IndexByte(mem.B(p.body), b)
+	if i == -1 {
+		p.err = fmt.Errorf("parseUntil error %s", string(rune(b)))
+		return nil
+	}
+	p.cache = p.cache[:0]
+	p.cache = append(p.cache, p.body[:i]...)
+	p.skipN(i + 1)
+	return p.cache
+}

--- a/internal/stats/dmesg_common_test.go
+++ b/internal/stats/dmesg_common_test.go
@@ -1,0 +1,30 @@
+package stats
+
+import "testing"
+
+func BenchmarkMesgStats_handleMsgs(b *testing.B) {
+	c := &DMesgStats{parser: &parser{}}
+	data := []byte(
+		`<4>[12555048.809330] audit: audit_lost=50409498 audit_rate_limit=0 audit_backlog_limit=8192
+<4>[12555059.240818] audit_log_start: 2 callbacks suppressed
+<4>[12555059.240819] audit: audit_backlog=2803588 > audit_backlog_limit=8192
+<4>[12555059.254320] audit: audit_lost=50409500 audit_rate_limit=0 audit_backlog_limit=8192
+<4>[12555065.440034] audit: audit_backlog=2803590 > audit_backlog_limit=8192
+<4>[12555065.447275] audit: audit_lost=50409501 audit_rate_limit=0 audit_backlog_limit=8192
+<4>[12555065.457472] audit: audit_backlog=2803590 > audit_backlog_limit=8192
+<4>[12555065.465353] audit: audit_lost=50409502 audit_rate_limit=0 audit_backlog_limit=8192
+<4>[12555065.474804] audit: audit_backlog=2803590 > audit_backlog_limit=8192
+<4>[12555065.482944] audit: audit_lost=50409503 audit_rate_limit=0 audit_backlog_limit=8192
+<4>[12555065.492439] audit: audit_backlog=2803590 > audit_backlog_limit=8192
+<4>[12555065.500576] audit: audit_lost=50409504 audit_rate_limit=0 audit_backlog_limit=8192
+<4>[12555065.510258] audit: audit_backlog=2803590 > audit_backlog_limit=8192
+<4>[12555065.517927] audit: audit_lost=50409505 audit_rate_limit=0 audit_backlog_limit=8192
+`)
+	for i := 0; i < b.N; i++ {
+		err := c.handleMsgs(0, data, false)
+		if err != nil {
+			panic(err)
+		}
+
+	}
+}

--- a/internal/stats/dmesg_linux.go
+++ b/internal/stats/dmesg_linux.go
@@ -1,0 +1,27 @@
+//go:build linux
+
+package stats
+
+import (
+	"fmt"
+	"syscall"
+
+	"github.com/vkcom/statshouse/internal/format"
+)
+
+func (c *DMesgStats) WriteMetrics(nowUnix int64) error {
+	n, err := syscall.Klogctl(SYSLOG_ACTION_SIZE_BUFFER, nil)
+	if err != nil {
+		return fmt.Errorf("failed to  %w", err)
+	}
+	b := make([]byte, n)
+	k, err := syscall.Klogctl(SYSLOG_ACTION_READ_ALL, b)
+	b = b[:k]
+	err = c.handleMsgs(nowUnix, b, c.pushStat)
+	c.pushStat = true
+	if err != nil {
+		c.writer.WriteSystemMetricValueWithoutHost(nowUnix, format.BuiltinMetricNameStatsHouseErrors, 0, format.TagValueIDDMESGParseError)
+		return errStopCollector
+	}
+	return nil
+}

--- a/internal/stats/dmesg_notlinux.go
+++ b/internal/stats/dmesg_notlinux.go
@@ -3,6 +3,8 @@
 package stats
 
 func (c *DMesgStats) WriteMetrics(nowUnix int64) error {
+	_ = c.pushMetric
 	_ = c.pushStat
+	_ = c.cache
 	return nil
 }

--- a/internal/stats/dmesg_notlinux.go
+++ b/internal/stats/dmesg_notlinux.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package stats
+
+func (c *DMesgStats) WriteMetrics(nowUnix int64) error {
+	_ = c.pushStat
+	return nil
+}

--- a/internal/stats/mem_stats.go
+++ b/internal/stats/mem_stats.go
@@ -15,7 +15,7 @@ type MemStats struct {
 	writer MetricWriter
 }
 
-const mem = format.BuiltinMetricNameMemUsage
+const memStat = format.BuiltinMetricNameMemUsage
 
 func (c *MemStats) Skip() bool {
 	return false
@@ -48,16 +48,16 @@ func (c *MemStats) WriteMetrics(nowUnix int64) error {
 	}
 
 	if stat.MemFree != nil {
-		c.writer.WriteSystemMetricValue(nowUnix, mem, float64(*stat.MemFree*mult), format.RawIDTagFree)
+		c.writer.WriteSystemMetricValue(nowUnix, memStat, float64(*stat.MemFree*mult), format.RawIDTagFree)
 	}
 	if stat.Buffers != nil {
-		c.writer.WriteSystemMetricValue(nowUnix, mem, float64(*stat.Buffers*mult), format.RawIDTagBuffers)
+		c.writer.WriteSystemMetricValue(nowUnix, memStat, float64(*stat.Buffers*mult), format.RawIDTagBuffers)
 	}
 	if stat.MemTotal != nil && stat.Buffers != nil && stat.Cached != nil && stat.SReclaimable != nil && stat.Shmem != nil && stat.MemFree != nil {
 		cached := *stat.Cached + *stat.SReclaimable - *stat.Shmem
 		used := *stat.MemTotal - *stat.MemFree - *stat.Buffers - cached
-		c.writer.WriteSystemMetricValue(nowUnix, mem, float64(used*mult), format.RawIDTagUsed)
-		c.writer.WriteSystemMetricValue(nowUnix, mem, float64(cached*mult), format.RawIDTagCached)
+		c.writer.WriteSystemMetricValue(nowUnix, memStat, float64(used*mult), format.RawIDTagUsed)
+		c.writer.WriteSystemMetricValue(nowUnix, memStat, float64(cached*mult), format.RawIDTagCached)
 	}
 
 	if stat.Writeback != nil && stat.Dirty != nil {


### PR DESCRIPTION
Читает klog и пишет 2 метрики.
`host_dmesg_events` - все новые эвенты с типом и уровнем
`host_oom_kill_detailed` - отдельная метрики для OOM но с названием процесса (в отличии от host_oom_kill, высчитывается на основе сообщений из klog)