### PR TITLE
Localrun: do not open page in browser if no gui available

### DIFF
--- a/localrun.sh
+++ b/localrun.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 set -e
 
+# copypasted https://stackoverflow.com/questions/54995983/how-to-detect-availability-of-gui-in-bash-shell
+check_macos_gui() {
+  command -v swift >/dev/null && swift <(cat <<"EOF"
+import Security
+var attrs = SessionAttributeBits(rawValue:0)
+let result = SessionGetInfo(callerSecuritySession, nil, &attrs)
+exit((result == 0 && attrs.contains(.sessionHasGraphicAccess)) ? 0 : 1)
+EOF
+)
+}
+
 PROFILE=sh
 case $1 in
   api-off|agent-off|aggregator-off|meta-off|all-in-one|scrape)
@@ -24,8 +35,8 @@ for c in sh sh-api; do
     until curl --output /dev/null --silent --head --fail http://localhost:10888/; do echo -n .; sleep 0.2; done
     URL="http://localhost:10888/view?live=1&f=-300&t=0&s=__contributors_log_rev"
     case "$OSTYPE" in
-      darwin*)  open "$URL" ;;
-      linux*)   xdg-open "$URL" ;;
+      darwin*)  if check_macos_gui ; then open "$URL" ; fi ;;
+      linux*) if [[ -n "$XDG_CURRENT_DESKTOP" ]] ; then xdg-open "$URL" ; fi ;;
     esac
     break
   fi


### PR DESCRIPTION
Usecase: run localrun under ssh on remote server