### PR TITLE
Update scrape

### DIFF
--- a/internal/aggregator/scrape_config.go
+++ b/internal/aggregator/scrape_config.go
@@ -234,12 +234,18 @@ func (s *scrapeConfigService) applyTargets(jobsM map[string][]*targetgroup.Group
 	// write static config
 	bytes, err := json.Marshal(res)
 	if err != nil {
-		log.Printf("failed to serialize scrape static config: %v", err)
+		log.Printf("failed to serialize scrape static config: %v\n", err)
 		return
 	}
-	_, err = s.meta.SaveScrapeStaticConfig(s.ctx, s.storage.PromConfigGenerated().Version, string(bytes))
+	newData := string(bytes)
+	current := s.storage.PromConfigGenerated()
+	if newData == current.Data {
+		log.Println("scrape static config remains unchanged")
+		return
+	}
+	_, err = s.meta.SaveScrapeStaticConfig(s.ctx, current.Version, newData)
 	if err != nil {
-		log.Printf("failed to save scrape static config: %v", err)
+		log.Printf("failed to save scrape static config: %v\n", err)
 	}
 }
 

--- a/internal/promql/engine.go
+++ b/internal/promql/engine.go
@@ -441,17 +441,6 @@ func (ev *evaluator) matchMetrics(sel *parser.VectorSelector, path []parser.Node
 			sel.MaxHostMatchers = append(sel.MaxHostMatchers, matcher)
 		}
 	}
-	for i := len(path); len(sel.MetricKindHint) == 0 && i != 0; i-- {
-		switch e := path[i-1].(type) {
-		case *parser.Call:
-			switch e.Func.Name {
-			case "delta", "deriv", "holt_winters", "idelta", "predict_linear":
-				sel.MetricKindHint = format.MetricKindValue
-			case "increase", "irate", "rate", "resets":
-				sel.MetricKindHint = format.MetricKindCounter
-			}
-		}
-	}
 	for i := len(path); !(sel.MinHost && sel.MaxHost) && i != 0; i-- {
 		if e, ok := path[i-1].(*parser.Call); ok {
 			switch e.Func.Name {
@@ -1025,7 +1014,7 @@ func (ev *evaluator) buildSeriesQuery(ctx context.Context, sel *parser.VectorSel
 	}
 	if len(whats) == 0 {
 		var what data_model.DigestWhat
-		if metric.Kind == format.MetricKindCounter || sel.MetricKindHint == format.MetricKindCounter {
+		if metric.Kind == format.MetricKindCounter {
 			what = data_model.DigestCountRaw
 		} else {
 			what = data_model.DigestAvg

--- a/internal/promql/functions.go
+++ b/internal/promql/functions.go
@@ -1439,6 +1439,9 @@ func (ev *evaluator) funcPrefixSum(sr Series) Series {
 }
 
 func funcRate(ev *evaluator, sr Series) Series {
+	if sr.Meta.Metric != nil && len(sr.Meta.Metric.HistorgamBuckets) != 0 {
+		return sr // Prometheus histograms are stored with "rate" function applied
+	}
 	t := ev.time()
 	for _, s := range sr.Data {
 		wnd := ev.newWindow(*s.Values, false)

--- a/internal/promql/parser/ast.go
+++ b/internal/promql/parser/ast.go
@@ -196,7 +196,6 @@ type VectorSelector struct {
 	PosRange PositionRange
 
 	MatchingMetrics []*format.MetricMetaValue
-	MetricKindHint  string
 	Range           int64
 	What            string
 	Whats           []string


### PR DESCRIPTION
"rate" function is nop for Prometheus histograms
eliminate writing of unchanged scrape config
return value for scrape counters