### PR TITLE
Add flag allow_experimental_analyzer = 0 to CH requests

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -676,7 +676,7 @@ ORDER BY
 LIMIT
   ?
 SETTINGS
-  optimize_aggregation_in_order = 1
+  optimize_aggregation_in_order = 1, allow_experimental_analyzer = 0
 `, _1sTableSH2), format.BuiltinMetricIDContributorsLog, from, cacheInvalidateMaxRows)
 	if err != nil {
 		log.Printf("[error] cache invalidation log query failed: %v", err)

--- a/internal/api/sql.go
+++ b/internal/api/sql.go
@@ -111,7 +111,7 @@ ORDER BY
   %s
 LIMIT %v
 SETTINGS
-  optimize_aggregation_in_order = 1
+  optimize_aggregation_in_order = 1, allow_experimental_analyzer = 0
 `, columnName(lod.HasPreKey, pq.tagID, pq.preKeyTagID), valueName, pq.numResults+1) // +1 so we can set "more":true
 
 	q, err := util.BindQuery(query, args...)
@@ -293,7 +293,7 @@ ORDER BY _time%s%s`, commaBy, desc)
 	query += fmt.Sprintf(`%s%s
 LIMIT %v
 SETTINGS
-  optimize_aggregation_in_order = 1
+  optimize_aggregation_in_order = 1, allow_experimental_analyzer = 0
 `, having, oderBy, limit)
 	q, err := util.BindQuery(query, args...)
 	return q, pointsQueryMeta{vals: cnt, tags: pq.by, minMaxHost: pq.kind != data_model.DigestKindCount, version: pq.version}, err
@@ -369,7 +369,7 @@ GROUP BY %s
 HAVING _count > 0
 LIMIT %v
 SETTINGS
-  optimize_aggregation_in_order = 1
+  optimize_aggregation_in_order = 1, allow_experimental_analyzer = 0
 `, maxSeriesRows)
 	q, err := util.BindQuery(query, args...)
 	return q, pointsQueryMeta{vals: cnt, tags: pq.by, minMaxHost: pq.kind != data_model.DigestKindCount, version: pq.version}, err


### PR DESCRIPTION
This flag is 0 by default in version 23.8 but becomes 1 by default in 24.3 which causes issues during update.