### PR TITLE
Shard by metric

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -387,7 +387,7 @@ func (s *BuiltInItemValue) Merge(s2 *data_model.ItemValue) {
 
 func (s *Agent) shardNumFromKey(key data_model.Key) int {
 	if s.shardByMetric.Load() {
-		metricId := int(key.Metric)
+		metricId := int(uint16(key.Metric))
 		// __badges and __src_ingestion_status are special cases
 		// they are sharded same way as metric they are used for
 		switch metricId {
@@ -396,7 +396,8 @@ func (s *Agent) shardNumFromKey(key data_model.Key) int {
 		case format.BuiltinMetricIDIngestionStatus:
 			metricId = int(key.Keys[1])
 		}
-		return metricId % len(s.Shards)
+		shardNum := metricId % s.NumShards()
+		return shardNum
 	}
 
 	hash := key.Hash()

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -475,7 +475,13 @@ func (s *Agent) ApplyMetric(m tlstatshouse.MetricBytes, h data_model.MappedMetri
 
 	keyHash := h.Key.Hash()
 	if s.shardByMetric.Load() {
-		shardNum := int(h.Key.Metric) % len(s.Shards)
+		metricId := int(h.Key.Metric)
+		if h.Key.Metric == format.BuiltinMetricIDBadges {
+			// __badges is a special case because it's created by us, extremely heavy, and always requested with metric
+			// we shard it same way as metric it's used for
+			metricId = int(h.Key.Keys[2])
+		}
+		shardNum := metricId % len(s.Shards)
 		if shardNum < 0 {
 			shardNum += len(s.Shards)
 		}

--- a/internal/agent/agent_shard.go
+++ b/internal/agent/agent_shard.go
@@ -55,7 +55,8 @@ type (
 		BuiltInItemValues []*BuiltInItemValue // Moved into CurrentBuckets before flush
 
 		PreprocessingBucketTime uint32
-		PreprocessingBuckets    []*data_model.MetricsBucket // current FutureQueue element is moved here
+		PreprocessingBuckets    []*data_model.MetricsBucket     // current FutureQueue element is moved here
+		carryBuckets            [60][]*data_model.MetricsBucket // only used from goPreProcess so accessed without lock
 		condPreprocess          *sync.Cond
 
 		// only used by single shard randomly selected for sending this infp

--- a/internal/agent/agent_shard_replica.go
+++ b/internal/agent/agent_shard_replica.go
@@ -64,6 +64,11 @@ func (s *ShardReplica) FillStats(stats map[string]string) {
 
 func (s *ShardReplica) sendSourceBucketCompressed(ctx context.Context, cbd compressedBucketData, historic bool, spare bool, ret *[]byte, shard *Shard) error {
 	extra := rpc.InvokeReqExtra{FailIfNoConnection: true}
+	var sharding int32
+	// it might be lie for historic metric, but for our purpose it's good enough
+	if shard.agent.shardByMetric.Load() {
+		sharding = 1
+	}
 	args := tlstatshouse.SendSourceBucket2Bytes{
 		Time:            cbd.time,
 		BuildCommit:     []byte(build.Commit()),
@@ -77,6 +82,7 @@ func (s *ShardReplica) sendSourceBucketCompressed(ctx context.Context, cbd compr
 	s.fillProxyHeaderBytes(&args.FieldsMask, &args.Header)
 	args.SetHistoric(historic)
 	args.SetSpare(spare)
+	args.SetSharding(sharding)
 
 	sizeMem := shard.HistoricBucketsDataSizeMemory()
 	if sizeMem < math.MaxInt32 {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -15,6 +15,7 @@ import (
 	"pgregory.net/rand"
 
 	"github.com/vkcom/statshouse/internal/data_model"
+	"github.com/vkcom/statshouse/internal/data_model/gen2/tlstatshouse"
 	"github.com/vkcom/statshouse/internal/format"
 )
 
@@ -190,4 +191,137 @@ func Benchmark_sampleFactorDeterministic(b *testing.B) {
 			result++
 		}
 	}
+}
+
+func Test_AgentSharding(t *testing.T) {
+	config := Config{
+		ShardByMetric: true,
+	}
+	agent := &Agent{
+		config: config,
+		logF:   func(f string, a ...any) { fmt.Printf(f, a...) },
+	}
+	agent.shardByMetric.Store(config.ShardByMetric)
+	startTime := time.Unix(1000*24*3600, 0) // arbitrary deterministic test time
+	nowUnix := uint32(startTime.Unix())
+
+	agent.Shards = make([]*Shard, 5)
+	for i := range agent.Shards {
+		shard := &Shard{
+			ShardNum:        i,
+			config:          config,
+			agent:           agent,
+			addBuiltInsTime: nowUnix,
+		}
+		for r := range shard.CurrentBuckets {
+			if r != format.AllowedResolution(r) {
+				continue
+			}
+			ur := uint32(r)
+			bucketTime := (nowUnix / ur) * ur
+			shard.CurrentBuckets[r] = &data_model.MetricsBucket{Time: bucketTime, Resolution: r}
+			shard.NextBuckets[r] = &data_model.MetricsBucket{Time: bucketTime + ur, Resolution: r}
+		}
+		shard.cond = sync.NewCond(&shard.mu)
+		shard.condPreprocess = sync.NewCond(&shard.mu)
+		agent.Shards[i] = shard
+	}
+
+	rng := rand.New()
+	for i := 0; i < 1000; i++ {
+		applyRandCountMetric(agent, rng, nowUnix)
+		applyRandValueMetric(agent, rng, nowUnix)
+		applyRandUniqueMetric(agent, rng, nowUnix)
+	}
+
+	totalCount := 0
+	for si, shard := range agent.Shards {
+		shardCount := 0
+		for _, b := range shard.CurrentBuckets {
+			if b == nil {
+				continue
+			}
+			for key := range b.MultiItems {
+				shardCount++
+				expectedShardNum := agent.shardNumFromKey(key)
+				if expectedShardNum != si {
+					t.Fatalf("failed for metric %v expected shard %d but got %d", key, expectedShardNum, si)
+				}
+			}
+		}
+		t.Log("shard", si, "count", shardCount)
+		totalCount += shardCount
+	}
+	// totalCount is twice as much because each metric is duplicated by __src_ingestion_status
+	if totalCount != 6000 {
+		t.Fatalf("expected to have 6000 metrics added to shards but got only %d", totalCount)
+	}
+}
+
+func randKey(rng *rand.Rand, ts uint32, metricOffset int32) data_model.Key {
+	key := data_model.Key{
+		Timestamp: ts,
+		Metric:    metricOffset + rng.Int31n(100_000),
+		Keys:      [16]int32{},
+	}
+	tagsN := rng.Int31n(16)
+	for t := 0; t < int(tagsN); t++ {
+		key.Keys[t] = rng.Int31n(100_000)
+	}
+	return key
+}
+
+func randResolution(rng *rand.Rand) int {
+	resolutions := []int{1, 5, 6, 10, 15, 20, 30, 60}
+	return resolutions[rng.Int31n(int32(len(resolutions)))]
+}
+
+func applyRandCountMetric(a *Agent, rng *rand.Rand, ts uint32) {
+	m := tlstatshouse.MetricBytes{
+		Counter: float64(1 + rng.Int31n(100)),
+	}
+	h := data_model.MappedMetricHeader{
+		Key: randKey(rng, ts, 1),
+		MetricInfo: &format.MetricMetaValue{
+			EffectiveResolution: randResolution(rng),
+		},
+	}
+	a.ApplyMetric(m, h, format.TagValueIDAggMappingStatusOKCached)
+}
+
+func applyRandValueMetric(a *Agent, rng *rand.Rand, ts uint32) {
+	count := 1 + rng.Int31n(100)
+	m := tlstatshouse.MetricBytes{
+		Counter: float64(count),
+		Value:   make([]float64, count),
+	}
+	for i := range m.Value {
+		m.Value[i] = rng.Float64()
+	}
+	h := data_model.MappedMetricHeader{
+		Key: randKey(rng, ts, 100_001),
+		MetricInfo: &format.MetricMetaValue{
+			EffectiveResolution: randResolution(rng),
+		},
+	}
+	a.ApplyMetric(m, h, format.TagValueIDAggMappingStatusOKCached)
+}
+
+func applyRandUniqueMetric(a *Agent, rng *rand.Rand, ts uint32) {
+	count := 1 + rng.Int31n(10)
+	m := tlstatshouse.MetricBytes{
+		Counter: float64(count),
+		Unique:  make([]int64, count),
+	}
+	for i := range m.Unique {
+		m.Unique[i] = rng.Int63n(1000)
+	}
+	h := data_model.MappedMetricHeader{
+		Key: randKey(rng, ts, 200_001),
+		MetricInfo: &format.MetricMetaValue{
+			EffectiveResolution: randResolution(rng),
+			ShardUniqueValues:   true,
+		},
+	}
+	a.ApplyMetric(m, h, format.TagValueIDAggMappingStatusOKCached)
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -86,10 +86,8 @@ func Test_AgentQueue(t *testing.T) {
 		}
 		ur := uint32(r)
 		bucketTime := (nowUnix / ur) * ur
-		for sh := 0; sh < r; sh++ {
-			shard.CurrentBuckets[r] = append(shard.CurrentBuckets[r], &data_model.MetricsBucket{Time: bucketTime, Resolution: r})
-			shard.NextBuckets[r] = append(shard.NextBuckets[r], &data_model.MetricsBucket{Time: bucketTime + ur, Resolution: r})
-		}
+		shard.CurrentBuckets[r] = &data_model.MetricsBucket{Time: bucketTime, Resolution: r}
+		shard.NextBuckets[r] = &data_model.MetricsBucket{Time: bucketTime + ur, Resolution: r}
 	}
 	shard.cond = sync.NewCond(&shard.mu)
 	shard.condPreprocess = sync.NewCond(&shard.mu)
@@ -110,9 +108,9 @@ func Test_AgentQueue(t *testing.T) {
 	testEnsureFlush(t, shard, nowUnix)
 	shard.PreprocessingBuckets = nil
 	agent.AddCounterHost(data_model.Key{Timestamp: nowUnix + 1, Metric: 1}, 1, 0, metric1sec)
-	agent.AddCounterHost(data_model.Key{Timestamp: nowUnix + 1, Metric: 5}, 1, 0, metric5sec)
-	agent.AddCounterHost(data_model.Key{Timestamp: nowUnix + 2, Metric: 1}, 1, 0, metric1sec)
-	agent.AddCounterHost(data_model.Key{Timestamp: nowUnix + 2, Metric: 5}, 1, 0, metric5sec)
+	agent.AddCounterHost(data_model.Key{Timestamp: nowUnix + 1, Metric: 5}, 2, 0, metric5sec)
+	agent.AddCounterHost(data_model.Key{Timestamp: nowUnix + 2, Metric: 1}, 3, 0, metric1sec)
+	agent.AddCounterHost(data_model.Key{Timestamp: nowUnix + 2, Metric: 5}, 4, 0, metric5sec)
 	agent.goFlushIteration(startTime.Add(2 * time.Second))
 	testEnsureNoFlush(t, shard)
 	for i := 1; i < 12; i++ { // wait until 5-seconds metrics flushed

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -37,7 +37,8 @@ type Config struct {
 	SaveSecondsImmediately bool // If false, will only go to disk if first send fails
 	StatsHouseEnv          string
 	Cluster                string
-	SkipShards             int // if cluster is extended, first shard might be almost full, so we can skip them for some time.
+	SkipShards             int  // if cluster is extended, first shard might be almost full, so we can skip them for some time.
+	ShardByMetric          bool // use new sharding algoritm where metric as a whole is in a single shard
 
 	// "remote write" was never used (so never tested) and was dropped
 	RemoteWriteEnabled bool
@@ -65,6 +66,7 @@ func DefaultConfig() Config {
 		KeepAliveSuccessTimeout:          time.Second * 5, // aggregator puts keep-alive requests in a bucket most soon to be inserted, so this is larger than strictly required
 		SaveSecondsImmediately:           false,
 		StatsHouseEnv:                    "production",
+		ShardByMetric:                    false,
 		RemoteWriteEnabled:               false,
 		RemoteWriteAddr:                  ":13380",
 		RemoteWritePath:                  "/write",
@@ -89,6 +91,7 @@ func (c *Config) Bind(f *flag.FlagSet, d Config, legacyVerb bool) {
 
 	f.BoolVar(&c.SaveSecondsImmediately, "save-seconds-immediately", d.SaveSecondsImmediately, "Save data to disk as soon as second is ready. When false, data is saved after first unsuccessful send.")
 	f.StringVar(&c.StatsHouseEnv, "statshouse-env", d.StatsHouseEnv, "Fill key0 with this value in built-in statistics. Only 'production' and 'staging' values are allowed.")
+	f.BoolVar(&c.ShardByMetric, "shard-by-metric", d.ShardByMetric, "Use new sharding algoritm where metric as a whole lives in a single shard.")
 
 	f.BoolVar(&c.RemoteWriteEnabled, "remote-write-enabled", d.RemoteWriteEnabled, "Serve prometheus remote write endpoint (deprecated).")
 	f.StringVar(&c.RemoteWriteAddr, "remote-write-addr", d.RemoteWriteAddr, "Prometheus remote write listen address (deprecated).")

--- a/internal/api/handler_easyjson.go
+++ b/internal/api/handler_easyjson.go
@@ -504,6 +504,8 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat(in *jlexer.Lex
 				}
 				in.Delim(']')
 			}
+		case "sharding":
+			easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat2(in, &out.Sharding)
 		default:
 			in.SkipRecursive()
 		}
@@ -659,6 +661,67 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat(out *jwriter.W
 			}
 			out.RawByte(']')
 		}
+	}
+	if true {
+		const prefix string = ",\"sharding\":"
+		out.RawString(prefix)
+		easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat2(out, in.Sharding)
+	}
+	out.RawByte('}')
+}
+func easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat2(in *jlexer.Lexer, out *format.MetricSharding) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "strategy":
+			out.Strategy = string(in.String())
+		case "shard":
+			(out.Shard).UnmarshalEasyJSON(in)
+		case "tag_id":
+			(out.TagId).UnmarshalEasyJSON(in)
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat2(out *jwriter.Writer, in format.MetricSharding) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"strategy\":"
+		out.RawString(prefix[1:])
+		out.String(string(in.Strategy))
+	}
+	if (in.Shard).IsDefined() {
+		const prefix string = ",\"shard\":"
+		out.RawString(prefix)
+		(in.Shard).MarshalEasyJSON(out)
+	}
+	if (in.TagId).IsDefined() {
+		const prefix string = ",\"tag_id\":"
+		out.RawString(prefix)
+		(in.TagId).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }
@@ -1202,7 +1265,7 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi5(in *jlexer.Lexer
 		}
 		switch key {
 		case "namespace":
-			easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat2(in, &out.Namespace)
+			easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat3(in, &out.Namespace)
 		default:
 			in.SkipRecursive()
 		}
@@ -1220,7 +1283,7 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi5(out *jwriter.Wri
 	{
 		const prefix string = ",\"namespace\":"
 		out.RawString(prefix[1:])
-		easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat2(out, in.Namespace)
+		easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat3(out, in.Namespace)
 	}
 	out.RawByte('}')
 }
@@ -1234,7 +1297,7 @@ func (v NamespaceInfo) MarshalEasyJSON(w *jwriter.Writer) {
 func (v *NamespaceInfo) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi5(l, v)
 }
-func easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat2(in *jlexer.Lexer, out *format.NamespaceMeta) {
+func easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat3(in *jlexer.Lexer, out *format.NamespaceMeta) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1277,7 +1340,7 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat2(in *jlexer.Le
 		in.Consumed()
 	}
 }
-func easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat2(out *jwriter.Writer, in format.NamespaceMeta) {
+func easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat3(out *jwriter.Writer, in format.NamespaceMeta) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1338,7 +1401,7 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi6(in *jlexer.Lexer
 		}
 		switch key {
 		case "group":
-			easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat3(in, &out.Group)
+			easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat4(in, &out.Group)
 		case "metrics":
 			if in.IsNull() {
 				in.Skip()
@@ -1379,7 +1442,7 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi6(out *jwriter.Wri
 	{
 		const prefix string = ",\"group\":"
 		out.RawString(prefix[1:])
-		easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat3(out, in.Group)
+		easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat4(out, in.Group)
 	}
 	{
 		const prefix string = ",\"metrics\":"
@@ -1409,7 +1472,7 @@ func (v MetricsGroupInfo) MarshalEasyJSON(w *jwriter.Writer) {
 func (v *MetricsGroupInfo) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi6(l, v)
 }
-func easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat3(in *jlexer.Lexer, out *format.MetricsGroup) {
+func easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat4(in *jlexer.Lexer, out *format.MetricsGroup) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1452,7 +1515,7 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat3(in *jlexer.Le
 		in.Consumed()
 	}
 }
-func easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat3(out *jwriter.Writer, in format.MetricsGroup) {
+func easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat4(out *jwriter.Writer, in format.MetricsGroup) {
 	out.RawByte('{')
 	first := true
 	_ = first


### PR DESCRIPTION
- alternative sharding method when metric gets into a single shad altogether, disabled by remote config by default because two sharding strategies simultaneously will cause problems
- no more sharding inside one resolution instead uniformly split bucket after processing starts
