### PR TITLE
fix binlog cache

### DIFF
--- a/internal/sqlitev2/engine.go
+++ b/internal/sqlitev2/engine.go
@@ -547,6 +547,7 @@ func (e *Engine) DoTx(ctx context.Context, queryName string, do func(c Conn, cac
 	if err != nil {
 		return res, fmt.Errorf("binlog Append return error: %w", err)
 	}
+	e.rw.binlogCache = bytes[:0]
 	err = e.rw.binlogCommitTxLocked(offsetAfterWrite)
 	return DoTxResult{
 		DBOffset: offsetAfterWrite,

--- a/internal/sqlitev2/engine_bench_test.go
+++ b/internal/sqlitev2/engine_bench_test.go
@@ -107,9 +107,14 @@ func BenchmarkReadNumbers(b *testing.B) {
 		return c.Query("select", "SELECT n FROM numbers WHERE n = $n", r[i%len(r)])
 	})
 }
+
 func BenchmarkWrite(b *testing.B) {
 	const schemeNumbers = "CREATE TABLE IF NOT EXISTS numbers (n INTEGER PRIMARY KEY);"
 	eng, _ := initDb(b, schemeNumbers, b.TempDir(), "test.db", true)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
 	var bytes [32]byte
 	for i := 0; i < b.N; i++ {
 		_, err := eng.DoTx(context.Background(), "dododo", func(c Conn, cache []byte) ([]byte, error) {
@@ -120,7 +125,7 @@ func BenchmarkWrite(b *testing.B) {
 			panic(err)
 		}
 	}
-	fmt.Println("CLOSE")
+
 	err := eng.Close()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
```
old 46125	     24401 ns/op	     120 B/op	      10 allocs/op
new 46501	     24575 ns/op	      88 B/op	       9 allocs/op
```