### PR TITLE
Speedup api docker build

### DIFF
--- a/build/statshouse-api.Dockerfile
+++ b/build/statshouse-api.Dockerfile
@@ -1,38 +1,40 @@
 FROM node:18-bullseye AS build-node
-ARG BUILD_TIME
-ARG BUILD_VERSION
-ARG REACT_APP_BUILD_VERSION
-ENV BUILD_TIME=$BUILD_TIME
-ENV BUILD_VERSION=$BUILD_VERSION
-ENV REACT_APP_BUILD_VERSION=$REACT_APP_BUILD_VERSION
-WORKDIR /src
-COPY Makefile ./
-COPY statshouse-ui/ ./statshouse-ui/
-RUN make build-sh-ui
+ENV NODE_ENV=production
+WORKDIR /src/statshouse-ui
+COPY statshouse-ui/package.json statshouse-ui/package-lock.json ./
+RUN npm clean-install
+# ARG BUILD_TIME
+# ARG BUILD_VERSION
+# ARG REACT_APP_BUILD_VERSION
+# ENV BUILD_TIME=$BUILD_TIME
+# ENV BUILD_VERSION=$BUILD_VERSION
+# ENV REACT_APP_BUILD_VERSION=$REACT_APP_BUILD_VERSION
+COPY statshouse-ui .
+RUN --mount=type=cache,target="/root/.npm" npm run build
+
 
 FROM golang:1.21-bullseye AS build-go
-ARG BUILD_TIME
-ARG BUILD_MACHINE
-ARG BUILD_COMMIT
-ARG BUILD_COMMIT_TS
-ARG BUILD_ID
-ARG BUILD_VERSION
-ARG BUILD_TRUSTED_SUBNET_GROUPS
-ENV BUILD_TIME=$BUILD_TIME
-ENV BUILD_MACHINE=$BUILD_MACHINE
-ENV BUILD_COMMIT=$BUILD_COMMIT
-ENV BUILD_COMMIT_TS=$BUILD_COMMIT_TS
-ENV BUILD_ID=$BUILD_ID
-ENV BUILD_VERSION=$BUILD_VERSION
-ENV BUILD_TRUSTED_SUBNET_GROUPS=$BUILD_TRUSTED_SUBNET_GROUPS
 WORKDIR /src
+RUN apt-get update && apt-get install -y gnuplot-nox gnuplot-data libpango-1.0-0 libcairo2
 COPY go.mod go.sum Makefile ./
+RUN go mod download -x
+# ARG BUILD_TIME
+# ARG BUILD_MACHINE
+# ARG BUILD_COMMIT
+# ARG BUILD_COMMIT_TS
+# ARG BUILD_ID
+# ARG BUILD_VERSION
+ARG BUILD_TRUSTED_SUBNET_GROUPS
+# ENV BUILD_TIME=$BUILD_TIME
+# ENV BUILD_MACHINE=$BUILD_MACHINE
+# ENV BUILD_COMMIT=$BUILD_COMMIT
+# ENV BUILD_COMMIT_TS=$BUILD_COMMIT_TS
+# ENV BUILD_ID=$BUILD_ID
+# ENV BUILD_VERSION=$BUILD_VERSION
+ENV BUILD_TRUSTED_SUBNET_GROUPS=$BUILD_TRUSTED_SUBNET_GROUPS
 COPY cmd/ ./cmd/
 COPY internal/ ./internal/
-RUN go mod download -x
-RUN make build-sh-api
-# dependencies for /api/render uncomment if needed
-# RUN apt-get update && apt-get install -y gnuplot-nox gnuplot-data libpango-1.0-0 libcairo2
+RUN --mount=type=cache,target="/root/.cache/go-build" --mount=type=cache,target="/go" make build-sh-api
 
 FROM gcr.io/distroless/base-debian11:nonroot
 WORKDIR /var/lib/statshouse/cache/api


### PR DESCRIPTION
1. added build caches
2. removed unnecessary arguments that caused rebuild (mostly `BUILD_TIME` because it is always new)
3. split npm build into two stages so that clean-install is called only if package.json package-lock.json were changed