### PR TITLE
[stats] add 'route' tag to __gc_duration metric

### DIFF
--- a/internal/format/builtin.go
+++ b/internal/format/builtin.go
@@ -2309,6 +2309,7 @@ Value is delta between second value and time it was inserted.`,
 		BuiltinMetricIDSrcSamplingBudget:         true,
 		BuiltinMetricIDSrcSamplingGroupBudget:    true,
 		BuiltinMetricIDRestartTimings:            true,
+		BuiltinMetricIDGCDuration:                true,
 	}
 
 	metricsWithoutAggregatorID = map[int32]bool{


### PR DESCRIPTION
<img width="1369" alt="image" src="https://github.com/user-attachments/assets/e60bff6e-37c9-45ef-8f04-fd2c92c106ec">
