### PR TITLE
Shard by metric info data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,12 @@ gen-sqlite:
 	@echo "Checking that generated code actually compiles..."
 	@go build ./internal/sqlitev2/checkpoint/gen2/...
 
-.PHONY: lint
+.PHONY: lint test check
 lint:
 	staticcheck -version
 	staticcheck ./...
+
+test:
+	go test -v -race ./...
+
+check: lint test

--- a/cmd/statshouse/shutdown_info.go
+++ b/cmd/statshouse/shutdown_info.go
@@ -31,53 +31,53 @@ func shutdownInfoReport(sh2 *agent.Agent, componentTag int32, storageDir string,
 		// arbitrary check that if start took more than 1 hour, this was not restart, and we do not want such case in our averages
 		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
 			Keys: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseInactive}},
-			dur.Seconds(), 1, nil)
+			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	if dur := time.Duration(si.StopRecentSenders); dur > 0 {
 		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
 			Keys: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopRecentSenders}},
-			dur.Seconds(), 1, nil)
+			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	if dur := time.Duration(si.StopReceivers); dur > 0 {
 		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
 			Keys: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopReceivers}},
-			dur.Seconds(), 1, nil)
+			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	if dur := time.Duration(si.StopFlusher); dur > 0 {
 		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
 			Keys: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopFlusher}},
-			dur.Seconds(), 1, nil)
+			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	if dur := time.Duration(si.StopFlushing); dur > 0 {
 		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
 			Keys: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopFlushing}},
-			dur.Seconds(), 1, nil)
+			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	if dur := time.Duration(si.StopPreprocessor); dur > 0 {
 		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
 			Keys: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopPreprocessor}},
-			dur.Seconds(), 1, nil)
+			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	if dur := time.Duration(si.StopInserters); dur > 0 {
 		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
 			Keys: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopInserters}},
-			dur.Seconds(), 1, nil)
+			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	if dur := time.Duration(si.StopRPCServer); dur > 0 {
 		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
 			Keys: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopRPCServer}},
-			dur.Seconds(), 1, nil)
+			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	finishLoadingTime := time.Now()
 	if dur := startDiscCache.Sub(globalStartTime); dur > 0 {
 		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
 			Keys: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStartDiskCache}},
-			dur.Seconds(), 1, nil)
+			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	if dur := finishLoadingTime.Sub(startDiscCache); dur > 0 {
 		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
 			Keys: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStartService}},
-			dur.Seconds(), 1, nil)
+			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 
 	startShutdownTime := time.Unix(0, si.StartShutdownTime)
@@ -85,7 +85,7 @@ func shutdownInfoReport(sh2 *agent.Agent, componentTag int32, storageDir string,
 		// arbitrary check that if start took more than 1 hour, this was not restart, and we do not want such case in our averages
 		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
 			Keys: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseTotal}},
-			dur.Seconds(), 1, nil)
+			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 		logOk.Printf("restart finished in %v (since shutdown start time recorded by previous instance)", dur)
 	} else {
 		logOk.Printf("start finished in %v (since this main() launched)", time.Since(globalStartTime))

--- a/cmd/statshouse/statshouse.go
+++ b/cmd/statshouse/statshouse.go
@@ -290,12 +290,12 @@ func mainAgent(aesPwd string, dc *pcache.DiskCache) int {
 			}
 			for _, r := range receiversUDP {
 				v := float64(r.ReceiveBufferSize())
-				a.AddValueCounter(k, v, 1, nil)
+				a.AddValueCounter(k, v, 1, format.BuiltinMetricMetaAgentUDPReceiveBufferSize)
 			}
 			if dc != nil {
 				s, err := dc.DiskSizeBytes()
 				if err == nil {
-					a.AddValueCounter(data_model.Key{Timestamp: unixNow, Metric: format.BuiltinMetricIDAgentDiskCacheSize, Keys: [16]int32{0, 0, 0}}, float64(s), 1, nil)
+					a.AddValueCounter(data_model.Key{Timestamp: unixNow, Metric: format.BuiltinMetricIDAgentDiskCacheSize, Keys: [16]int32{0, 0, 0}}, float64(s), 1, format.BuiltinMetricMetaAgentDiskCacheSize)
 				}
 			}
 		},

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -564,7 +564,13 @@ func (s *Agent) ApplyMetric(m tlstatshouse.MetricBytes, h data_model.MappedMetri
 
 	keyHash := h.Key.Hash()
 	if s.shardByMetric.Load() {
-		shardNum := int(h.Key.Metric) % len(s.Shards)
+		metricId := int(h.Key.Metric)
+		if h.Key.Metric == format.BuiltinMetricIDBadges {
+			// __badges is a special case because it's created by us, extremely heavy, and always requested with metric
+			// we shard it same way as metric it's used for
+			metricId = int(h.Key.Keys[2])
+		}
+		shardNum := metricId % len(s.Shards)
 		if shardNum < 0 {
 			shardNum += len(s.Shards)
 		}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -580,7 +580,7 @@ func (s *Agent) ApplyMetric(m tlstatshouse.MetricBytes, h data_model.MappedMetri
 		// if we shard by metric all values of a given metric will go to the same shard anyway,
 		// so there is no need for special sharding for unique values
 		numShards := s.NumShards()
-		if h.MetricInfo != nil && h.MetricInfo.ShardUniqueValues && numShards > 1 && h.MetricInfo.Sharding.Strategy == format.MappedTags {
+		if h.MetricInfo != nil && h.MetricInfo.ShardUniqueValues && numShards > 1 && h.MetricInfo.Sharding.Strategy == format.ShardByMappedTags {
 			// we want unique value sets to have no intersections
 			// so we first shard by unique value, then shard among 3 replicas by keys
 			skipShards := int(s.skipShards.Load())

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -489,15 +489,25 @@ func (s *Agent) shardNumFromHash(hash uint64) int {
 	return int(mul)
 }
 
-func (s *Agent) shardFromHash(hash uint64) *Shard {
+func (s *Agent) shardFromKey(key data_model.Key) *Shard {
+	if s.shardByMetric.Load() {
+		metricId := int(key.Metric)
+		if key.Metric == format.BuiltinMetricIDBadges {
+			// __badges is a special case because it's created by us, extremely heavy, and always requested with metric
+			// we shard it same way as metric it's used for
+			metricId = int(key.Keys[2])
+		}
+		shardNum := metricId % len(s.Shards)
+		return s.Shards[shardNum]
+	}
+	hash := key.Hash()
 	return s.Shards[s.shardNumFromHash(hash)]
 }
 
 // Do not create too many. ShardReplicas will iterate through values before flushing bucket
 // Useful for watermark metrics.
 func (s *Agent) CreateBuiltInItemValue(key data_model.Key) *BuiltInItemValue {
-	keyHash := key.Hash()
-	shard := s.shardFromHash(keyHash)
+	shard := s.shardFromKey(key)
 	return shard.CreateBuiltInItemValue(key)
 }
 
@@ -562,32 +572,6 @@ func (s *Agent) ApplyMetric(m tlstatshouse.MetricBytes, h data_model.MappedMetri
 	// using single metric as a "namespace" for "sub-metrics" of different kinds.
 	// The only thing we check is if percentiles are allowed. This is configured per metric.
 
-	keyHash := h.Key.Hash()
-	if s.shardByMetric.Load() {
-		metricId := int(h.Key.Metric)
-		if h.Key.Metric == format.BuiltinMetricIDBadges {
-			// __badges is a special case because it's created by us, extremely heavy, and always requested with metric
-			// we shard it same way as metric it's used for
-			metricId = int(h.Key.Keys[2])
-		}
-		shardNum := metricId % len(s.Shards)
-		if shardNum < 0 {
-			shardNum += len(s.Shards)
-		}
-		shard := s.Shards[shardNum]
-		if len(m.Unique) != 0 {
-			shard.ApplyUnique(h.Key, keyHash, h.SValue, m.Unique, m.Counter, h.HostTag, h.MetricInfo)
-			return
-		}
-		if len(m.Value) != 0 {
-			shard.ApplyValues(h.Key, keyHash, h.SValue, m.Value, m.Counter, h.HostTag, h.MetricInfo)
-			return
-		}
-		if m.Counter > 0 {
-			shard.ApplyCounter(h.Key, keyHash, h.SValue, m.Counter, h.HostTag, h.MetricInfo)
-		}
-		return
-	}
 	// here m.Unique and m.Value cannot be both non-empty
 	// also m.Counter is >= 0
 	//
@@ -603,12 +587,13 @@ func (s *Agent) ApplyMetric(m tlstatshouse.MetricBytes, h data_model.MappedMetri
 	// so if counter is 20, and Uniques len is 3, we simply add each of 3 events to HLL
 	// with a twist, that we also store min/max/sum/sumsquare of unique values converted to float64
 	// for the purpose of this, Uniques are treated exactly as Values
-	shardNum := s.shardNumFromHash(keyHash)
-	shard := s.Shards[shardNum]
 	// m.Counter is >= 0 here, otherwise IngestionStatus is not OK, and we returned above
+	shard := s.shardFromKey(h.Key)
 	if len(m.Unique) != 0 {
+		// if we shard by metric all values of a given metric will go to the same shard anyway,
+		// so there is no need for special sharding for unique values
 		numShards := s.NumShards()
-		if h.MetricInfo != nil && h.MetricInfo.ShardUniqueValues && numShards > 1 {
+		if h.MetricInfo != nil && h.MetricInfo.ShardUniqueValues && numShards > 1 && !s.shardByMetric.Load() {
 			// we want unique value sets to have no intersections
 			// so we first shard by unique value, then shard among 3 replicas by keys
 			skipShards := int(s.skipShards.Load())
@@ -658,7 +643,7 @@ func (s *Agent) AddCounterHost(key data_model.Key, count float64, hostTag int32,
 		return
 	}
 	keyHash := key.Hash()
-	shard := s.shardFromHash(keyHash)
+	shard := s.shardFromKey(key)
 	shard.AddCounterHost(key, keyHash, count, hostTag, metricInfo)
 }
 
@@ -669,7 +654,7 @@ func (s *Agent) AddCounterHostStringBytes(key data_model.Key, str []byte, count 
 		return
 	}
 	keyHash := key.Hash()
-	shard := s.shardFromHash(keyHash)
+	shard := s.shardFromKey(key)
 	shard.AddCounterHostStringBytes(key, keyHash, str, count, hostTag, metricInfo)
 }
 
@@ -678,7 +663,7 @@ func (s *Agent) AddValueCounterHost(key data_model.Key, value float64, counter f
 		return
 	}
 	keyHash := key.Hash()
-	shard := s.shardFromHash(keyHash)
+	shard := s.shardFromKey(key)
 	shard.AddValueCounterHost(key, keyHash, value, counter, hostTag, nil)
 }
 
@@ -688,7 +673,7 @@ func (s *Agent) AddValueCounter(key data_model.Key, value float64, counter float
 		return
 	}
 	keyHash := key.Hash()
-	shard := s.shardFromHash(keyHash)
+	shard := s.shardFromKey(key)
 	shard.AddValueCounterHost(key, keyHash, value, counter, 0, metricInfo)
 }
 
@@ -698,7 +683,7 @@ func (s *Agent) AddValueCounterHostArray(key data_model.Key, values []float64, m
 		return
 	}
 	keyHash := key.Hash()
-	shard := s.shardFromHash(keyHash)
+	shard := s.shardFromKey(key)
 	shard.AddValueArrayCounterHost(key, keyHash, values, mult, hostTag, metricInfo)
 }
 */
@@ -708,7 +693,7 @@ func (s *Agent) AddValueArrayCounterHostStringBytes(key data_model.Key, values [
 		return
 	}
 	keyHash := key.Hash()
-	shard := s.shardFromHash(keyHash)
+	shard := s.shardFromKey(key)
 	shard.AddValueArrayCounterHostStringBytes(key, keyHash, values, mult, hostTag, str, metricInfo)
 }
 
@@ -717,7 +702,7 @@ func (s *Agent) AddValueCounterHostStringBytes(key data_model.Key, value float64
 		return
 	}
 	keyHash := key.Hash()
-	shard := s.shardFromHash(keyHash)
+	shard := s.shardFromKey(key)
 	shard.AddValueCounterHostStringBytes(key, keyHash, value, counter, hostTag, str, nil)
 }
 
@@ -726,14 +711,14 @@ func (s *Agent) MergeItemValue(key data_model.Key, item *data_model.ItemValue, m
 		return
 	}
 	keyHash := key.Hash()
-	shard := s.shardFromHash(keyHash)
+	shard := s.shardFromKey(key)
 	shard.MergeItemValue(key, keyHash, item, metricInfo)
 }
 
 func (s *Agent) AddUniqueHostStringBytes(key data_model.Key, hostTag int32, str []byte, hashes []int64, count float64, metricInfo *format.MetricMetaValue) {
 	keyHash := key.Hash()
-	shard := s.shardFromHash(keyHash)
-	shard.ApplyUnique(key, keyHash, str, hashes, count, hostTag, metricInfo)
+	shard := s.shardFromKey(key)
+	shard.AddUniqueHostStringBytes(key, hostTag, str, keyHash, hashes, count, metricInfo)
 }
 
 func (s *Agent) AggKey(time uint32, metricID int32, keys [format.MaxTags]int32) data_model.Key {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -482,7 +482,7 @@ func (s *BuiltInItemValue) SetValueCounter(value float64, count float64) {
 // Do not create too many. ShardReplicas will iterate through values before flushing bucket
 // Useful for watermark metrics.
 func (s *Agent) CreateBuiltInItemValue(key data_model.Key, meta *format.MetricMetaValue) *BuiltInItemValue {
-	shardId, _, err := sharding.Shard(key, meta, s.NumShards())
+	shardId, _, err := sharding.Shard(key, meta, s.NumShards(), s.builtinNewSharding.Load())
 	if err != nil {
 		return nil
 	}
@@ -503,7 +503,7 @@ func (s *Agent) ApplyMetric(m tlstatshouse.MetricBytes, h data_model.MappedMetri
 		}, h.InvalidString, 1, 0, format.BuiltinMetricMetaIngestionStatus)
 		return
 	}
-	shardId, strategy, err := sharding.Shard(h.Key, h.MetricInfo, s.NumShards())
+	shardId, strategy, err := sharding.Shard(h.Key, h.MetricInfo, s.NumShards(), s.builtinNewSharding.Load())
 	if err != nil {
 		s.AddCounter(data_model.Key{
 			Metric: format.BuiltinMetricIDIngestionStatus,
@@ -630,7 +630,7 @@ func (s *Agent) AddCounterHost(key data_model.Key, count float64, hostTag int32,
 	if count <= 0 {
 		return
 	}
-	shardId, _, err := sharding.Shard(key, metricInfo, s.NumShards())
+	shardId, _, err := sharding.Shard(key, metricInfo, s.NumShards(), s.builtinNewSharding.Load())
 	if err != nil {
 		return
 	}
@@ -646,7 +646,7 @@ func (s *Agent) AddCounterHostStringBytes(key data_model.Key, str []byte, count 
 		return
 	}
 	keyHash := key.Hash()
-	shardId, _, err := sharding.Shard(key, metricInfo, s.NumShards())
+	shardId, _, err := sharding.Shard(key, metricInfo, s.NumShards(), s.builtinNewSharding.Load())
 	if err != nil {
 		return
 	}
@@ -659,7 +659,7 @@ func (s *Agent) AddValueCounterHost(key data_model.Key, value float64, counter f
 		return
 	}
 	keyHash := key.Hash()
-	shardId, _, err := sharding.Shard(key, metricInfo, s.NumShards())
+	shardId, _, err := sharding.Shard(key, metricInfo, s.NumShards(), s.builtinNewSharding.Load())
 	if err != nil {
 		return
 	}
@@ -673,7 +673,7 @@ func (s *Agent) AddValueCounter(key data_model.Key, value float64, counter float
 		return
 	}
 	keyHash := key.Hash()
-	shardId, _, err := sharding.Shard(key, metricInfo, s.NumShards())
+	shardId, _, err := sharding.Shard(key, metricInfo, s.NumShards(), s.builtinNewSharding.Load())
 	if err != nil {
 		return
 	}
@@ -686,7 +686,7 @@ func (s *Agent) AddValueArrayCounterHostStringBytes(key data_model.Key, values [
 		return
 	}
 	keyHash := key.Hash()
-	shardId, _, err := sharding.Shard(key, metricInfo, s.NumShards())
+	shardId, _, err := sharding.Shard(key, metricInfo, s.NumShards(), s.builtinNewSharding.Load())
 	if err != nil {
 		return
 	}
@@ -699,7 +699,7 @@ func (s *Agent) AddValueCounterHostStringBytes(key data_model.Key, value float64
 		return
 	}
 	keyHash := key.Hash()
-	shardId, _, err := sharding.Shard(key, metricInfo, s.NumShards())
+	shardId, _, err := sharding.Shard(key, metricInfo, s.NumShards(), s.builtinNewSharding.Load())
 	if err != nil {
 		return
 	}
@@ -712,7 +712,7 @@ func (s *Agent) MergeItemValue(key data_model.Key, item *data_model.ItemValue, m
 		return
 	}
 	keyHash := key.Hash()
-	shardId, _, err := sharding.Shard(key, metricInfo, s.NumShards())
+	shardId, _, err := sharding.Shard(key, metricInfo, s.NumShards(), s.builtinNewSharding.Load())
 	if err != nil {
 		return
 	}
@@ -725,7 +725,7 @@ func (s *Agent) AddUniqueHostStringBytes(key data_model.Key, hostTag int32, str 
 		return
 	}
 	keyHash := key.Hash()
-	shardId, _, err := sharding.Shard(key, metricInfo, s.NumShards())
+	shardId, _, err := sharding.Shard(key, metricInfo, s.NumShards(), s.builtinNewSharding.Load())
 	if err != nil {
 		return
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -65,7 +65,6 @@ type Agent struct {
 
 	statshouseRemoteConfigString string       // optimization
 	skipShards                   atomic.Int32 // copy from config.
-	shardByMetric                atomic.Bool  // copy from config.
 
 	rUsage                syscall.Rusage // accessed without lock by first shard addBuiltIns
 	heartBeatEventType    int32          // first time "start", then "heartbeat"
@@ -412,7 +411,6 @@ func (s *Agent) updateConfigRemotelyExperimental() {
 	} else {
 		s.skipShards.Store(0)
 	}
-	s.shardByMetric.Store(config.ShardByMetric)
 	for _, shard := range s.Shards {
 		shard.mu.Lock()
 		shard.config = config

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -64,6 +64,7 @@ type Agent struct {
 
 	statshouseRemoteConfigString string       // optimization
 	skipShards                   atomic.Int32 // copy from config.
+	shardByMetric                atomic.Bool  // copy from config.
 
 	rUsage                syscall.Rusage // accessed without lock by first shard addBuiltIns
 	heartBeatEventType    int32          // first time "start", then "heartbeat"
@@ -410,6 +411,7 @@ func (s *Agent) updateConfigRemotelyExperimental() {
 	} else {
 		s.skipShards.Store(0)
 	}
+	s.shardByMetric.Store(config.ShardByMetric)
 	for _, shard := range s.Shards {
 		shard.mu.Lock()
 		shard.config = config
@@ -561,8 +563,11 @@ func (s *Agent) ApplyMetric(m tlstatshouse.MetricBytes, h data_model.MappedMetri
 	// The only thing we check is if percentiles are allowed. This is configured per metric.
 
 	keyHash := h.Key.Hash()
-	if s.config.ShardByMetric {
+	if s.shardByMetric.Load() {
 		shardNum := int(h.Key.Metric) % len(s.Shards)
+		if shardNum < 0 {
+			shardNum += len(s.Shards)
+		}
 		shard := s.Shards[shardNum]
 		if len(m.Unique) != 0 {
 			shard.ApplyUnique(h.Key, keyHash, h.SValue, m.Unique, m.Counter, h.HostTag, h.MetricInfo)
@@ -574,8 +579,8 @@ func (s *Agent) ApplyMetric(m tlstatshouse.MetricBytes, h data_model.MappedMetri
 		}
 		if m.Counter > 0 {
 			shard.ApplyCounter(h.Key, keyHash, h.SValue, m.Counter, h.HostTag, h.MetricInfo)
-			return
 		}
+		return
 	}
 	// here m.Unique and m.Value cannot be both non-empty
 	// also m.Counter is >= 0

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -480,7 +480,7 @@ func (s *BuiltInItemValue) SetValueCounter(value float64, count float64) {
 
 func (s *Agent) shardNumFromKey(key data_model.Key) int {
 	if s.shardByMetric.Load() {
-		metricId := int(key.Metric)
+		metricId := int(uint16(key.Metric))
 		// __badges and __src_ingestion_status are special cases
 		// they are sharded same way as metric they are used for
 		switch metricId {
@@ -489,7 +489,8 @@ func (s *Agent) shardNumFromKey(key data_model.Key) int {
 		case format.BuiltinMetricIDIngestionStatus:
 			metricId = int(key.Keys[1])
 		}
-		return metricId % len(s.Shards)
+		shardNum := metricId % s.NumShards()
+		return shardNum
 	}
 
 	hash := key.Hash()

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -560,6 +560,23 @@ func (s *Agent) ApplyMetric(m tlstatshouse.MetricBytes, h data_model.MappedMetri
 	// using single metric as a "namespace" for "sub-metrics" of different kinds.
 	// The only thing we check is if percentiles are allowed. This is configured per metric.
 
+	keyHash := h.Key.Hash()
+	if s.config.ShardByMetric {
+		shardNum := int(h.Key.Metric) % len(s.Shards)
+		shard := s.Shards[shardNum]
+		if len(m.Unique) != 0 {
+			shard.ApplyUnique(h.Key, keyHash, h.SValue, m.Unique, m.Counter, h.HostTag, h.MetricInfo)
+			return
+		}
+		if len(m.Value) != 0 {
+			shard.ApplyValues(h.Key, keyHash, h.SValue, m.Value, m.Counter, h.HostTag, h.MetricInfo)
+			return
+		}
+		if m.Counter > 0 {
+			shard.ApplyCounter(h.Key, keyHash, h.SValue, m.Counter, h.HostTag, h.MetricInfo)
+			return
+		}
+	}
 	// here m.Unique and m.Value cannot be both non-empty
 	// also m.Counter is >= 0
 	//
@@ -575,9 +592,8 @@ func (s *Agent) ApplyMetric(m tlstatshouse.MetricBytes, h data_model.MappedMetri
 	// so if counter is 20, and Uniques len is 3, we simply add each of 3 events to HLL
 	// with a twist, that we also store min/max/sum/sumsquare of unique values converted to float64
 	// for the purpose of this, Uniques are treated exactly as Values
-	keyHash := h.Key.Hash()
-	shordNum := s.shardNumFromHash(keyHash)
-	shard := s.Shards[shordNum]
+	shardNum := s.shardNumFromHash(keyHash)
+	shard := s.Shards[shardNum]
 	// m.Counter is >= 0 here, otherwise IngestionStatus is not OK, and we returned above
 	if len(m.Unique) != 0 {
 		numShards := s.NumShards()

--- a/internal/agent/agent_loaders.go
+++ b/internal/agent/agent_loaders.go
@@ -173,7 +173,7 @@ func (s *Agent) LoadMetaMetricJournal(ctxParent context.Context, version int64, 
 	// On the other hand, if aggregators cannot map, but can insert, system is working
 	// So, we must have separate live-dead status for mappings - TODO
 	if s0 == nil {
-		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusAllDead}}, 0, 1, nil)
+		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusAllDead}}, 0, 1, format.BuiltinMetricMetaAgentMapping)
 		return nil, version, fmt.Errorf("cannot load meta journal, all aggregators are dead")
 	}
 	now := time.Now()
@@ -189,15 +189,15 @@ func (s *Agent) LoadMetaMetricJournal(ctxParent context.Context, version int64, 
 	// We do not need timeout for long poll, RPC has disconnect detection via ping-pong
 	err := s0.client.GetMetrics3(ctxParent, args, &extra, &ret)
 	if err != nil {
-		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusErrSingle}}, time.Since(now).Seconds(), 1, nil)
+		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusErrSingle}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
 		return nil, version, fmt.Errorf("cannot load meta journal - %w", err)
 	}
 	/*
 		for _, r := range ret.Events {
-				s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusErrSingle}}, time.Since(now).Seconds(), 1, false, nil)
+				s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusErrSingle}}, time.Since(now).Seconds(), 1, false, format.BuiltinMetricIDAgentMapping)
 		}
 	*/
-	s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusOKFirst}}, time.Since(now).Seconds(), 1, nil)
+	s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusOKFirst}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
 	return ret.Events, ret.CurrentVersion, nil
 }
 
@@ -206,7 +206,7 @@ func (s *Agent) LoadOrCreateMapping(ctxParent context.Context, key string, flood
 	// Use 2 alive random aggregators for mapping
 	s0, s1 := s.getRandomLiveShardReplicas()
 	if s0 == nil {
-		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusAllDead}}, 0, 1, nil)
+		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusAllDead}}, 0, 1, format.BuiltinMetricMetaAgentMapping)
 		return nil, 0, fmt.Errorf("all aggregators are dead")
 	}
 	now := time.Now()

--- a/internal/agent/agent_loaders.go
+++ b/internal/agent/agent_loaders.go
@@ -232,11 +232,11 @@ func (s *Agent) LoadOrCreateMapping(ctxParent context.Context, key string, flood
 	defer cancel()
 	err := s0.client.GetTagMapping2(ctx, args, &extra, &ret)
 	if err == nil {
-		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusOKFirst}}, time.Since(now).Seconds(), 1, nil)
+		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusOKFirst}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
 		return pcache.Int32ToValue(ret.Value), time.Duration(ret.TtlNanosec), nil
 	}
 	if s1 == nil {
-		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusErrSingle}}, time.Since(now).Seconds(), 1, nil)
+		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusErrSingle}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
 		return nil, 0, fmt.Errorf("the only live aggregator %q returned error: %w", s0.client.Address, err)
 	}
 
@@ -246,10 +246,10 @@ func (s *Agent) LoadOrCreateMapping(ctxParent context.Context, key string, flood
 	defer cancel2()
 	err2 := s1.client.GetTagMapping2(ctx2, args, &extra, &ret)
 	if err2 == nil {
-		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusOKSecond}}, time.Since(now).Seconds(), 1, nil)
+		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusOKSecond}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
 		return pcache.Int32ToValue(ret.Value), time.Duration(ret.TtlNanosec), nil
 	}
-	s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusErrBoth}}, time.Since(now).Seconds(), 1, nil)
+	s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusErrBoth}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
 	return nil, 0, fmt.Errorf("two live aggregators %q %q returned errors: %v %w", s0.client.Address, s1.client.Address, err, err2)
 }
 

--- a/internal/agent/agent_shard_replica.go
+++ b/internal/agent/agent_shard_replica.go
@@ -64,6 +64,11 @@ func (s *ShardReplica) FillStats(stats map[string]string) {
 
 func (s *ShardReplica) sendSourceBucketCompressed(ctx context.Context, cbd compressedBucketData, historic bool, spare bool, ret *[]byte, shard *Shard) error {
 	extra := rpc.InvokeReqExtra{FailIfNoConnection: true}
+	var sharding int32
+	// it might be lie for historic metric, but for our purpose it's good enough
+	if shard.agent.shardByMetric.Load() {
+		sharding = 1
+	}
 	args := tlstatshouse.SendSourceBucket2Bytes{
 		Time:            cbd.time,
 		BuildCommit:     []byte(build.Commit()),
@@ -77,6 +82,7 @@ func (s *ShardReplica) sendSourceBucketCompressed(ctx context.Context, cbd compr
 	s.fillProxyHeaderBytes(&args.FieldsMask, &args.Header)
 	args.SetHistoric(historic)
 	args.SetSpare(spare)
+	args.SetSharding(sharding)
 
 	sizeMem := shard.HistoricBucketsDataSizeMemory()
 	if sizeMem < math.MaxInt32 {

--- a/internal/agent/agent_shard_replica.go
+++ b/internal/agent/agent_shard_replica.go
@@ -65,10 +65,6 @@ func (s *ShardReplica) FillStats(stats map[string]string) {
 func (s *ShardReplica) sendSourceBucketCompressed(ctx context.Context, cbd compressedBucketData, historic bool, spare bool, ret *[]byte, shard *Shard) error {
 	extra := rpc.InvokeReqExtra{FailIfNoConnection: true}
 	var sharding int32
-	// it might be lie for historic metric, but for our purpose it's good enough
-	if shard.agent.shardByMetric.Load() {
-		sharding = 1
-	}
 	args := tlstatshouse.SendSourceBucket2Bytes{
 		Time:            cbd.time,
 		BuildCommit:     []byte(build.Commit()),

--- a/internal/agent/agent_shard_replica.go
+++ b/internal/agent/agent_shard_replica.go
@@ -64,7 +64,6 @@ func (s *ShardReplica) FillStats(stats map[string]string) {
 
 func (s *ShardReplica) sendSourceBucketCompressed(ctx context.Context, cbd compressedBucketData, historic bool, spare bool, ret *[]byte, shard *Shard) error {
 	extra := rpc.InvokeReqExtra{FailIfNoConnection: true}
-	var sharding int32
 	args := tlstatshouse.SendSourceBucket2Bytes{
 		Time:            cbd.time,
 		BuildCommit:     []byte(build.Commit()),
@@ -78,7 +77,6 @@ func (s *ShardReplica) sendSourceBucketCompressed(ctx context.Context, cbd compr
 	s.fillProxyHeaderBytes(&args.FieldsMask, &args.Header)
 	args.SetHistoric(historic)
 	args.SetSpare(spare)
-	args.SetSharding(sharding)
 
 	sizeMem := shard.HistoricBucketsDataSizeMemory()
 	if sizeMem < math.MaxInt32 {

--- a/internal/agent/agent_shard_replica.go
+++ b/internal/agent/agent_shard_replica.go
@@ -203,21 +203,21 @@ func (s *ShardReplica) InitBuiltInMetric() {
 	// Unfortunately we do not know aggregator host tag.
 	s.successTestConnectionDurationBucket = s.agent.CreateBuiltInItemValue(data_model.AggKey(0,
 		format.BuiltinMetricIDSrcTestConnection,
-		[16]int32{0, s.agent.componentTag, format.TagOKConnection}, 0, s.ShardKey, s.ReplicaKey))
+		[16]int32{0, s.agent.componentTag, format.TagOKConnection}, 0, s.ShardKey, s.ReplicaKey), format.BuiltinMetricMetaSrcTestConnection)
 	s.noConnectionTestConnectionDurationBucket = s.agent.CreateBuiltInItemValue(data_model.AggKey(0,
 		format.BuiltinMetricIDSrcTestConnection,
-		[16]int32{0, s.agent.componentTag, format.TagNoConnection}, 0, s.ShardKey, s.ReplicaKey))
+		[16]int32{0, s.agent.componentTag, format.TagNoConnection}, 0, s.ShardKey, s.ReplicaKey), format.BuiltinMetricMetaSrcTestConnection)
 	s.failedTestConnectionDurationBucket = s.agent.CreateBuiltInItemValue(data_model.AggKey(0,
 		format.BuiltinMetricIDSrcTestConnection,
-		[16]int32{0, s.agent.componentTag, format.TagOtherError}, 0, s.ShardKey, s.ReplicaKey))
+		[16]int32{0, s.agent.componentTag, format.TagOtherError}, 0, s.ShardKey, s.ReplicaKey), format.BuiltinMetricMetaSrcTestConnection)
 	s.rpcErrorTestConnectionDurationBucket = s.agent.CreateBuiltInItemValue(data_model.AggKey(0,
 		format.BuiltinMetricIDSrcTestConnection,
-		[16]int32{0, s.agent.componentTag, format.TagRPCError}, 0, s.ShardKey, s.ReplicaKey))
+		[16]int32{0, s.agent.componentTag, format.TagRPCError}, 0, s.ShardKey, s.ReplicaKey), format.BuiltinMetricMetaSrcTestConnection)
 	s.timeoutTestConnectionDurationBucket = s.agent.CreateBuiltInItemValue(data_model.AggKey(0,
 		format.BuiltinMetricIDSrcTestConnection,
-		[16]int32{0, s.agent.componentTag, format.TagTimeoutError}, 0, s.ShardKey, s.ReplicaKey))
+		[16]int32{0, s.agent.componentTag, format.TagTimeoutError}, 0, s.ShardKey, s.ReplicaKey), format.BuiltinMetricMetaSrcTestConnection)
 
 	s.aggTimeDiffBucket = s.agent.CreateBuiltInItemValue(data_model.AggKey(0,
 		format.BuiltinMetricIDAgentAggregatorTimeDiff,
-		[16]int32{0, s.agent.componentTag}, 0, s.ShardKey, s.ReplicaKey))
+		[16]int32{0, s.agent.componentTag}, 0, s.ShardKey, s.ReplicaKey), format.BuiltinMetricMetaAgentAggregatorTimeDiff)
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -15,6 +15,7 @@ import (
 	"pgregory.net/rand"
 
 	"github.com/mailru/easyjson/opt"
+
 	"github.com/vkcom/statshouse/internal/data_model"
 	"github.com/vkcom/statshouse/internal/data_model/gen2/tlstatshouse"
 	"github.com/vkcom/statshouse/internal/format"
@@ -201,14 +202,11 @@ func Benchmark_sampleFactorDeterministic(b *testing.B) {
 }
 
 func Test_AgentSharding(t *testing.T) {
-	config := Config{
-		ShardByMetric: true,
-	}
+	config := Config{}
 	agent := &Agent{
 		config: config,
 		logF:   func(f string, a ...any) { fmt.Printf(f, a...) },
 	}
-	agent.shardByMetric.Store(config.ShardByMetric)
 	startTime := time.Unix(1000*24*3600, 0) // arbitrary deterministic test time
 	nowUnix := uint32(startTime.Unix())
 
@@ -232,7 +230,6 @@ func Test_AgentSharding(t *testing.T) {
 			}
 		}
 		shard.cond = sync.NewCond(&shard.mu)
-		shard.condPreprocess = sync.NewCond(&shard.mu)
 		agent.Shards[i] = shard
 	}
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -207,6 +207,7 @@ func Test_AgentSharding(t *testing.T) {
 		config: config,
 		logF:   func(f string, a ...any) { fmt.Printf(f, a...) },
 	}
+	agent.builtinNewSharding.Store(true)
 	startTime := time.Unix(1000*24*3600, 0) // arbitrary deterministic test time
 	nowUnix := uint32(startTime.Unix())
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -276,11 +276,11 @@ func Test_AgentSharding(t *testing.T) {
 					shardCount += int(sh.MultiItems[key].Tail.Value.Count())
 					expectedShardNum := uint32(0) // buitin metrics
 					if key.Metric > 0 && key.Metric < 300_001 {
-						expectedShardNum, _, _ = sharding.Shard(key, fixedShard(nil, key), agent.NumShards())
+						expectedShardNum, _, _ = sharding.Shard(key, fixedShard(nil, key), agent.NumShards(), true)
 					} else if key.Metric >= 300_001 {
-						expectedShardNum, _, _ = sharding.Shard(key, byMappedTags(nil, key), agent.NumShards())
+						expectedShardNum, _, _ = sharding.Shard(key, byMappedTags(nil, key), agent.NumShards(), true)
 					} else if key.Metric == format.BuiltinMetricIDIngestionStatus {
-						expectedShardNum, _, _ = sharding.Shard(key, byTagIngestion, agent.NumShards())
+						expectedShardNum, _, _ = sharding.Shard(key, byTagIngestion, agent.NumShards(), true)
 					}
 					if int(expectedShardNum) != si {
 						t.Fatalf("failed for metric %v expected shard %d but got %d", key, expectedShardNum, si)

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -239,14 +239,14 @@ func Test_AgentSharding(t *testing.T) {
 		if meta == nil {
 			meta = &format.MetricMetaValue{}
 		}
-		meta.Sharding = []format.MetricSharding{{Strategy: format.ShardByFixedShard, Shard: opt.OUint32(uint32(key.Metric) % 5)}}
+		meta.Sharding = []format.MetricSharding{{Strategy: format.ShardFixed, Shard: opt.OUint32(uint32(key.Metric) % 5)}}
 		return meta
 	}
 	byMappedTags := func(meta *format.MetricMetaValue, key data_model.Key) *format.MetricMetaValue {
 		if meta == nil {
 			meta = &format.MetricMetaValue{}
 		}
-		meta.Sharding = []format.MetricSharding{{Strategy: format.ShardByMappedTags}}
+		meta.Sharding = []format.MetricSharding{{Strategy: format.ShardBy16MappedTagsHash}}
 		return meta
 	}
 	byTagIngestion := &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByTag, TagId: opt.OUint32(1)}}}

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -37,7 +37,8 @@ type Config struct {
 	SaveSecondsImmediately bool // If false, will only go to disk if first send fails
 	StatsHouseEnv          string
 	Cluster                string
-	SkipShards             int // if cluster is extended, first shard might be almost full, so we can skip them for some time.
+	SkipShards             int  // if cluster is extended, first shard might be almost full, so we can skip them for some time.
+	ShardByMetric          bool // use new sharding algoritm where metric as a whole is in a single shard
 
 	// "remote write" was never used (so never tested) and was dropped
 	RemoteWriteEnabled bool
@@ -65,6 +66,7 @@ func DefaultConfig() Config {
 		KeepAliveSuccessTimeout:          time.Second * 5, // aggregator puts keep-alive requests in a bucket most soon to be inserted, so this is larger than strictly required
 		SaveSecondsImmediately:           false,
 		StatsHouseEnv:                    "production",
+		ShardByMetric:                    false,
 		RemoteWriteEnabled:               false,
 		RemoteWriteAddr:                  ":13380",
 		RemoteWritePath:                  "/write",
@@ -89,6 +91,7 @@ func (c *Config) Bind(f *flag.FlagSet, d Config, legacyVerb bool) {
 
 	f.BoolVar(&c.SaveSecondsImmediately, "save-seconds-immediately", d.SaveSecondsImmediately, "Save data to disk as soon as second is ready. When false, data is saved after first unsuccessful send.")
 	f.StringVar(&c.StatsHouseEnv, "statshouse-env", d.StatsHouseEnv, "Fill key0 with this value in built-in statistics. Only 'production' and 'staging' values are allowed.")
+	f.BoolVar(&c.ShardByMetric, "shard-by-metric", d.ShardByMetric, "Use new sharding algoritm where metric as a whole lives in a single shard.")
 
 	f.BoolVar(&c.RemoteWriteEnabled, "remote-write-enabled", d.RemoteWriteEnabled, "Serve prometheus remote write endpoint (deprecated).")
 	f.StringVar(&c.RemoteWriteAddr, "remote-write-addr", d.RemoteWriteAddr, "Prometheus remote write listen address (deprecated).")

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -37,8 +37,7 @@ type Config struct {
 	SaveSecondsImmediately bool // If false, will only go to disk if first send fails
 	StatsHouseEnv          string
 	Cluster                string
-	SkipShards             int  // if cluster is extended, first shard might be almost full, so we can skip them for some time.
-	ShardByMetric          bool // use new sharding algoritm where metric as a whole is in a single shard
+	SkipShards             int // if cluster is extended, first shard might be almost full, so we can skip them for some time.
 
 	// "remote write" was never used (so never tested) and was dropped
 	RemoteWriteEnabled bool
@@ -66,7 +65,6 @@ func DefaultConfig() Config {
 		KeepAliveSuccessTimeout:          time.Second * 5, // aggregator puts keep-alive requests in a bucket most soon to be inserted, so this is larger than strictly required
 		SaveSecondsImmediately:           false,
 		StatsHouseEnv:                    "production",
-		ShardByMetric:                    false,
 		RemoteWriteEnabled:               false,
 		RemoteWriteAddr:                  ":13380",
 		RemoteWritePath:                  "/write",
@@ -91,7 +89,6 @@ func (c *Config) Bind(f *flag.FlagSet, d Config, legacyVerb bool) {
 
 	f.BoolVar(&c.SaveSecondsImmediately, "save-seconds-immediately", d.SaveSecondsImmediately, "Save data to disk as soon as second is ready. When false, data is saved after first unsuccessful send.")
 	f.StringVar(&c.StatsHouseEnv, "statshouse-env", d.StatsHouseEnv, "Fill key0 with this value in built-in statistics. Only 'production' and 'staging' values are allowed.")
-	f.BoolVar(&c.ShardByMetric, "shard-by-metric", d.ShardByMetric, "Use new sharding algoritm where metric as a whole lives in a single shard.")
 
 	f.BoolVar(&c.RemoteWriteEnabled, "remote-write-enabled", d.RemoteWriteEnabled, "Serve prometheus remote write endpoint (deprecated).")
 	f.StringVar(&c.RemoteWriteAddr, "remote-write-addr", d.RemoteWriteAddr, "Prometheus remote write listen address (deprecated).")

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	StatsHouseEnv          string
 	Cluster                string
 	SkipShards             int // if cluster is extended, first shard might be almost full, so we can skip them for some time.
+	BuiltinNewSharding     bool
 
 	// "remote write" was never used (so never tested) and was dropped
 	RemoteWriteEnabled bool
@@ -65,6 +66,7 @@ func DefaultConfig() Config {
 		KeepAliveSuccessTimeout:          time.Second * 5, // aggregator puts keep-alive requests in a bucket most soon to be inserted, so this is larger than strictly required
 		SaveSecondsImmediately:           false,
 		StatsHouseEnv:                    "production",
+		BuiltinNewSharding:               false, // false by default because agent deploy is slow, should be enabled after full deploy and then removed
 		RemoteWriteEnabled:               false,
 		RemoteWriteAddr:                  ":13380",
 		RemoteWritePath:                  "/write",
@@ -101,6 +103,7 @@ func (c *Config) Bind(f *flag.FlagSet, d Config, legacyVerb bool) {
 		f.BoolVar(&c.SampleNamespaces, "sample-namespaces", d.SampleNamespaces, "Statshouse will sample at namespace level.")
 		f.BoolVar(&c.SampleGroups, "sample-groups", d.SampleGroups, "Statshouse will sample at group level.")
 		f.BoolVar(&c.SampleKeys, "sample-keys", d.SampleKeys, "Statshouse will sample at key level.")
+		f.BoolVar(&c.BuiltinNewSharding, "buitin-new-sharding", d.BuiltinNewSharding, "Put builtin metrics into 0 shard, except for ingestion and bages which sharded by metric")
 	}
 
 	f.IntVar(&c.HardwareMetricResolution, "hardware-metric-resolution", d.HardwareMetricResolution, "Statshouse hardware metric resolution")

--- a/internal/aggregator/aggregator.go
+++ b/internal/aggregator/aggregator.go
@@ -471,9 +471,9 @@ func (a *Aggregator) agentBeforeFlushBucketFunc(_ *agent.Agent, nowUnix uint32) 
 	writeWaiting(format.BuiltinMetricIDAggHistoricHostsWaiting, &hostsWaiting)
 
 	key := a.aggKey(nowUnix, format.BuiltinMetricIDAggActiveSenders, [16]int32{0, 0, 0, 0, format.TagValueIDConveyorRecent})
-	a.sh2.AddValueCounterHost(key, float64(recentSenders), 1, a.aggregatorHost)
+	a.sh2.AddBuiltinValueCounterHost(key, float64(recentSenders), 1, a.aggregatorHost)
 	key = a.aggKey(nowUnix, format.BuiltinMetricIDAggActiveSenders, [16]int32{0, 0, 0, 0, format.TagValueIDConveyorHistoric})
-	a.sh2.AddValueCounterHost(key, float64(historicSends), 1, a.aggregatorHost)
+	a.sh2.AddBuiltinValueCounterHost(key, float64(historicSends), 1, a.aggregatorHost)
 
 	/* TODO - replace with direct agent call
 
@@ -669,7 +669,7 @@ func (a *Aggregator) goInsert(insertsSema *semaphore.Weighted, cancelCtx context
 				a.updateHistoricHostsLocked(a.historicHosts, historicHosts)
 				a.mu.Unlock()
 				key := a.aggKey(nowUnix, format.BuiltinMetricIDTimingErrors, [16]int32{0, format.TagValueIDTimingLongWindowThrownAggregatorLater})
-				a.sh2.AddValueCounterHost(key, float64(newestTime-b.time), 1, a.aggregatorHost) // This bucket is combination of many hosts
+				a.sh2.AddBuiltinValueCounterHost(key, float64(newestTime-b.time), 1, a.aggregatorHost) // This bucket is combination of many hosts
 			}
 			if historicBucket == nil {
 				break
@@ -726,11 +726,11 @@ func (a *Aggregator) goInsert(insertsSema *semaphore.Weighted, cancelCtx context
 			a.updateHistoricHostsLocked(a.historicHosts, historicHosts)
 			a.mu.Unlock()
 			// format.BuiltinMetricIDAggInsertSize was added during each bucket marshal
-			a.sh2.AddValueCounterHost(a.reportInsertKeys(b.time, format.BuiltinMetricIDAggInsertTime, i != 0, sendErr, status, exception), dur, 1, 0)
+			a.sh2.AddBuiltinValueCounterHost(a.reportInsertKeys(b.time, format.BuiltinMetricIDAggInsertTime, i != 0, sendErr, status, exception), dur, 1, 0)
 		}
 		// insert of all buckets is also accounted into single event at aggBucket.time second, so the graphic will be smoother
-		a.sh2.AddValueCounterHost(a.reportInsertKeys(aggBucket.time, format.BuiltinMetricIDAggInsertSizeReal, willInsertHistoric, sendErr, status, exception), float64(len(bodyStorage)), 1, 0)
-		a.sh2.AddValueCounterHost(a.reportInsertKeys(aggBucket.time, format.BuiltinMetricIDAggInsertTimeReal, willInsertHistoric, sendErr, status, exception), dur, 1, 0)
+		a.sh2.AddBuiltinValueCounterHost(a.reportInsertKeys(aggBucket.time, format.BuiltinMetricIDAggInsertSizeReal, willInsertHistoric, sendErr, status, exception), float64(len(bodyStorage)), 1, 0)
+		a.sh2.AddBuiltinValueCounterHost(a.reportInsertKeys(aggBucket.time, format.BuiltinMetricIDAggInsertTimeReal, willInsertHistoric, sendErr, status, exception), dur, 1, 0)
 
 		sendErr = fmt.Errorf("simulated error")
 		aggBucket.mu.Lock()

--- a/internal/aggregator/aggregator_handlers.go
+++ b/internal/aggregator/aggregator_handlers.go
@@ -213,7 +213,7 @@ func (a *Aggregator) handleSendSourceBucket2(_ context.Context, hctx *rpc.Handle
 			a.mu.Unlock()
 			key := a.aggKey(nowUnix, format.BuiltinMetricIDTimingErrors, [16]int32{0, format.TagValueIDTimingFutureBucketHistoric})
 			key = key.WithAgentEnvRouteArch(agentEnv, route, buildArch)
-			a.sh2.AddValueCounterHost(key, float64(args.Time)-float64(newestTime), 1, host)
+			a.sh2.AddBuiltinValueCounterHost(key, float64(args.Time)-float64(newestTime), 1, host)
 			// We discard, because otherwise clients will flood aggregators with this data
 			hctx.Response, _ = args.WriteResult(hctx.Response, []byte("historic bucket time is too far in the future"))
 			return nil
@@ -222,7 +222,7 @@ func (a *Aggregator) handleSendSourceBucket2(_ context.Context, hctx *rpc.Handle
 			a.mu.Unlock()
 			key := a.aggKey(nowUnix, format.BuiltinMetricIDTimingErrors, [16]int32{0, format.TagValueIDTimingLongWindowThrownAggregator})
 			key = key.WithAgentEnvRouteArch(agentEnv, route, buildArch)
-			a.sh2.AddValueCounterHost(key, float64(newestTime)-float64(args.Time), 1, host)
+			a.sh2.AddBuiltinValueCounterHost(key, float64(newestTime)-float64(args.Time), 1, host)
 			hctx.Response, _ = args.WriteResult(hctx.Response, []byte("Successfully discarded historic bucket beyond historic window"))
 			return nil
 		}
@@ -247,7 +247,7 @@ func (a *Aggregator) handleSendSourceBucket2(_ context.Context, hctx *rpc.Handle
 			a.mu.Unlock()
 			key := a.aggKey(nowUnix, format.BuiltinMetricIDTimingErrors, [16]int32{0, format.TagValueIDTimingFutureBucketRecent})
 			key = key.WithAgentEnvRouteArch(agentEnv, route, buildArch)
-			a.sh2.AddValueCounterHost(key, float64(args.Time)-float64(newestTime), 1, host)
+			a.sh2.AddBuiltinValueCounterHost(key, float64(args.Time)-float64(newestTime), 1, host)
 			// We discard, because otherwise clients will flood aggregators with this data
 			hctx.Response, _ = args.WriteResult(hctx.Response, []byte("bucket time is too far in the future"))
 			return nil

--- a/internal/aggregator/aggregator_handlers.go
+++ b/internal/aggregator/aggregator_handlers.go
@@ -426,8 +426,6 @@ func (a *Aggregator) handleSendSourceBucket2(_ context.Context, hctx *rpc.Handle
 		getMultiItem(args.Time, format.BuiltinMetricIDAgentSamplingFactor, [16]int32{0, v.Metric}).Tail.AddValueCounterHost(rng, float64(v.Value), 1, host)
 	}
 
-	getMultiItem(args.Time, format.BuiltinMetricIDAggAgentSharding, [16]int32{0, 0, 0, 0, args.Sharding}).Tail.AddCounterHost(rng, 1, host)
-
 	ingestionStatus := func(env int32, metricID int32, status int32, value float32) {
 		data_model.MapKeyItemMultiItem(&s.multiItems, (data_model.Key{Timestamp: args.Time, Metric: format.BuiltinMetricIDIngestionStatus, Keys: [16]int32{env, metricID, status}}).WithAgentEnvRouteArch(agentEnv, route, buildArch), data_model.AggregatorStringTopCapacity, nil, nil).Tail.AddCounterHost(rng, float64(value), host)
 	}

--- a/internal/aggregator/aggregator_handlers.go
+++ b/internal/aggregator/aggregator_handlers.go
@@ -257,7 +257,7 @@ func (a *Aggregator) handleSendSourceBucket2(_ context.Context, hctx *rpc.Handle
 			key := a.aggKey(nowUnix, format.BuiltinMetricIDTimingErrors, [16]int32{0, format.TagValueIDTimingLateRecent})
 			key = key.WithAgentEnvRouteArch(agentEnv, route, buildArch)
 			a.sh2.AddValueCounterHost(key, float64(newestTime)-float64(args.Time), 1, host, format.BuiltinMetricMetaTimingErrors)
-			return rpc.Error{
+			return &rpc.Error{
 				Code:        data_model.RPCErrorMissedRecentConveyor,
 				Description: "bucket time is too far in the past for recent conveyor",
 			}

--- a/internal/aggregator/aggregator_handlers.go
+++ b/internal/aggregator/aggregator_handlers.go
@@ -213,7 +213,7 @@ func (a *Aggregator) handleSendSourceBucket2(_ context.Context, hctx *rpc.Handle
 			a.mu.Unlock()
 			key := a.aggKey(nowUnix, format.BuiltinMetricIDTimingErrors, [16]int32{0, format.TagValueIDTimingFutureBucketHistoric})
 			key = key.WithAgentEnvRouteArch(agentEnv, route, buildArch)
-			a.sh2.AddBuiltinValueCounterHost(key, float64(args.Time)-float64(newestTime), 1, host)
+			a.sh2.AddValueCounterHost(key, float64(args.Time)-float64(newestTime), 1, host, nil)
 			// We discard, because otherwise clients will flood aggregators with this data
 			hctx.Response, _ = args.WriteResult(hctx.Response, []byte("historic bucket time is too far in the future"))
 			return nil
@@ -222,7 +222,7 @@ func (a *Aggregator) handleSendSourceBucket2(_ context.Context, hctx *rpc.Handle
 			a.mu.Unlock()
 			key := a.aggKey(nowUnix, format.BuiltinMetricIDTimingErrors, [16]int32{0, format.TagValueIDTimingLongWindowThrownAggregator})
 			key = key.WithAgentEnvRouteArch(agentEnv, route, buildArch)
-			a.sh2.AddBuiltinValueCounterHost(key, float64(newestTime)-float64(args.Time), 1, host)
+			a.sh2.AddValueCounterHost(key, float64(newestTime)-float64(args.Time), 1, host, nil)
 			hctx.Response, _ = args.WriteResult(hctx.Response, []byte("Successfully discarded historic bucket beyond historic window"))
 			return nil
 		}
@@ -247,7 +247,7 @@ func (a *Aggregator) handleSendSourceBucket2(_ context.Context, hctx *rpc.Handle
 			a.mu.Unlock()
 			key := a.aggKey(nowUnix, format.BuiltinMetricIDTimingErrors, [16]int32{0, format.TagValueIDTimingFutureBucketRecent})
 			key = key.WithAgentEnvRouteArch(agentEnv, route, buildArch)
-			a.sh2.AddBuiltinValueCounterHost(key, float64(args.Time)-float64(newestTime), 1, host)
+			a.sh2.AddValueCounterHost(key, float64(args.Time)-float64(newestTime), 1, host, nil)
 			// We discard, because otherwise clients will flood aggregators with this data
 			hctx.Response, _ = args.WriteResult(hctx.Response, []byte("bucket time is too far in the future"))
 			return nil
@@ -256,8 +256,8 @@ func (a *Aggregator) handleSendSourceBucket2(_ context.Context, hctx *rpc.Handle
 			a.mu.Unlock()
 			key := a.aggKey(nowUnix, format.BuiltinMetricIDTimingErrors, [16]int32{0, format.TagValueIDTimingLateRecent})
 			key = key.WithAgentEnvRouteArch(agentEnv, route, buildArch)
-			a.sh2.AddValueCounterHost(key, float64(newestTime)-float64(args.Time), 1, host)
-			return &rpc.Error{
+			a.sh2.AddValueCounterHost(key, float64(newestTime)-float64(args.Time), 1, host, nil)
+			return rpc.Error{
 				Code:        data_model.RPCErrorMissedRecentConveyor,
 				Description: "bucket time is too far in the past for recent conveyor",
 			}

--- a/internal/aggregator/aggregator_insert.go
+++ b/internal/aggregator/aggregator_insert.go
@@ -60,13 +60,12 @@ func makeMetricCache(journal *metajournal.MetricsStorage) *metricIndexCache {
 		lastMetric:          lastMetricData{lastMetricPrekey: -1}, // so if somehow 0 metricID is inserted first, will have no prekey
 
 	}
-	if bm, ok := format.BuiltinMetrics[format.BuiltinMetricIDIngestionStatus]; ok {
-		result.ingestionStatusData.lastMetricPrekeyOnly = bm.PreKeyOnly
-		result.ingestionStatusData.lastMetricPrekey = bm.PreKeyIndex
-		result.ingestionStatusData.lastMetricSkipMinHost = bm.SkipMinHost
-		result.ingestionStatusData.lastMetricSkipMaxHost = bm.SkipMaxHost
-		result.ingestionStatusData.lastMetricSkipSumSquare = bm.SkipSumSquare
-	}
+	bm := format.BuiltinMetricMetaIngestionStatus
+	result.ingestionStatusData.lastMetricPrekeyOnly = bm.PreKeyOnly
+	result.ingestionStatusData.lastMetricPrekey = bm.PreKeyIndex
+	result.ingestionStatusData.lastMetricSkipMinHost = bm.SkipMinHost
+	result.ingestionStatusData.lastMetricSkipMaxHost = bm.SkipMaxHost
+	result.ingestionStatusData.lastMetricSkipSumSquare = bm.SkipSumSquare
 	return result
 }
 

--- a/internal/aggregator/autocreate.go
+++ b/internal/aggregator/autocreate.go
@@ -289,12 +289,12 @@ func (ac *autoCreate) createMetric(args tlstatshouse.AutoCreateBytes) error {
 	err = ac.client.EditEntitynew(ctx, edit, nil, &ret)
 	if err != nil {
 		tags[2] = 2 // failure
-		ac.agg.sh2.AddCounter(ac.agg.aggKey(uint32(time.Now().Unix()), format.BuiltinMetricIDAutoCreateMetric, tags), 1)
+		ac.agg.sh2.AddBuiltinCounter(ac.agg.aggKey(uint32(time.Now().Unix()), format.BuiltinMetricIDAutoCreateMetric, tags), 1)
 		return fmt.Errorf("failed to create or update metric: %w", err)
 	}
 	// succeeded, wait a bit until changes applied locally
 	tags[2] = 1 // success
-	ac.agg.sh2.AddCounter(ac.agg.aggKey(uint32(time.Now().Unix()), format.BuiltinMetricIDAutoCreateMetric, tags), 1)
+	ac.agg.sh2.AddBuiltinCounter(ac.agg.aggKey(uint32(time.Now().Unix()), format.BuiltinMetricIDAutoCreateMetric, tags), 1)
 	ctx, cancel = context.WithTimeout(ac.ctx, 5*time.Second)
 	defer cancel()
 	_ = ac.storage.Journal().WaitVersion(ctx, ret.Version)

--- a/internal/aggregator/autocreate.go
+++ b/internal/aggregator/autocreate.go
@@ -289,12 +289,12 @@ func (ac *autoCreate) createMetric(args tlstatshouse.AutoCreateBytes) error {
 	err = ac.client.EditEntitynew(ctx, edit, nil, &ret)
 	if err != nil {
 		tags[2] = 2 // failure
-		ac.agg.sh2.AddCounter(ac.agg.aggKey(uint32(time.Now().Unix()), format.BuiltinMetricIDAutoCreateMetric, tags), 1, nil)
+		ac.agg.sh2.AddCounter(ac.agg.aggKey(uint32(time.Now().Unix()), format.BuiltinMetricIDAutoCreateMetric, tags), 1, format.BuiltinMetricMetaAutoCreateMetric)
 		return fmt.Errorf("failed to create or update metric: %w", err)
 	}
 	// succeeded, wait a bit until changes applied locally
 	tags[2] = 1 // success
-	ac.agg.sh2.AddCounter(ac.agg.aggKey(uint32(time.Now().Unix()), format.BuiltinMetricIDAutoCreateMetric, tags), 1, nil)
+	ac.agg.sh2.AddCounter(ac.agg.aggKey(uint32(time.Now().Unix()), format.BuiltinMetricIDAutoCreateMetric, tags), 1, format.BuiltinMetricMetaAutoCreateMetric)
 	ctx, cancel = context.WithTimeout(ac.ctx, 5*time.Second)
 	defer cancel()
 	_ = ac.storage.Journal().WaitVersion(ctx, ret.Version)

--- a/internal/aggregator/autocreate.go
+++ b/internal/aggregator/autocreate.go
@@ -289,12 +289,12 @@ func (ac *autoCreate) createMetric(args tlstatshouse.AutoCreateBytes) error {
 	err = ac.client.EditEntitynew(ctx, edit, nil, &ret)
 	if err != nil {
 		tags[2] = 2 // failure
-		ac.agg.sh2.AddBuiltinCounter(ac.agg.aggKey(uint32(time.Now().Unix()), format.BuiltinMetricIDAutoCreateMetric, tags), 1)
+		ac.agg.sh2.AddCounter(ac.agg.aggKey(uint32(time.Now().Unix()), format.BuiltinMetricIDAutoCreateMetric, tags), 1, nil)
 		return fmt.Errorf("failed to create or update metric: %w", err)
 	}
 	// succeeded, wait a bit until changes applied locally
 	tags[2] = 1 // success
-	ac.agg.sh2.AddBuiltinCounter(ac.agg.aggKey(uint32(time.Now().Unix()), format.BuiltinMetricIDAutoCreateMetric, tags), 1)
+	ac.agg.sh2.AddCounter(ac.agg.aggKey(uint32(time.Now().Unix()), format.BuiltinMetricIDAutoCreateMetric, tags), 1, nil)
 	ctx, cancel = context.WithTimeout(ac.ctx, 5*time.Second)
 	defer cancel()
 	_ = ac.storage.Journal().WaitVersion(ctx, ret.Version)

--- a/internal/aggregator/scrape_discovery.go
+++ b/internal/aggregator/scrape_discovery.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/consul"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
+
 	"github.com/vkcom/statshouse/internal/agent"
 	"github.com/vkcom/statshouse/internal/format"
 	"github.com/vkcom/statshouse/internal/metajournal"
@@ -144,7 +145,7 @@ func (s *scrapeDiscovery) applyTargets(targets map[string][]*targetgroup.Group) 
 					if addr, ok := ls[model.AddressLabel]; ok {
 						s.sh2.AddCounterHostStringBytes(
 							s.sh2.AggKey(0, format.BuiltinMetricIDAggScrapeTargetDiscovery, [format.MaxTags]int32{}),
-							[]byte(addr), 1, 0, nil)
+							[]byte(addr), 1, 0, format.BuiltinMetricMetaAggScrapeTargetDiscovery)
 					}
 				}
 			}

--- a/internal/aggregator/scrape_server.go
+++ b/internal/aggregator/scrape_server.go
@@ -26,6 +26,8 @@ import (
 	_ "github.com/prometheus/prometheus/discovery/consul"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
+	"go.uber.org/atomic"
+
 	"github.com/vkcom/statshouse/internal/agent"
 	"github.com/vkcom/statshouse/internal/data_model"
 	"github.com/vkcom/statshouse/internal/data_model/gen2/tl"
@@ -33,7 +35,6 @@ import (
 	"github.com/vkcom/statshouse/internal/format"
 	"github.com/vkcom/statshouse/internal/metajournal"
 	"github.com/vkcom/statshouse/internal/vkgo/rpc"
-	"go.uber.org/atomic"
 )
 
 type scrapeServer struct {
@@ -232,7 +233,7 @@ func (s *scrapeServer) applyScrapeConfig(cs []ScrapeConfig) {
 				// success, targets_ready
 				s.sh2.AddCounterHostStringBytes(
 					s.sh2.AggKey(0, format.BuiltinMetricIDAggScrapeTargetDispatch, [format.MaxTags]int32{0, 0, 1}),
-					[]byte(host), 1, 0, nil)
+					[]byte(host), 1, 0, format.BuiltinMetricMetaAggScrapeTargetDispatch)
 			}
 		}
 	}()
@@ -268,7 +269,7 @@ func (s *scrapeServer) reportConfigHash(nowUnix uint32) {
 	v := s.configH.Load()
 	s.sh2.AddCounterHostStringBytes(
 		s.sh2.AggKey(nowUnix, format.BuiltinMetricIDAggScrapeConfigHash, [format.MaxTags]int32{0, v}),
-		nil, 1, 0, nil)
+		nil, 1, 0, format.BuiltinMetricMetaAggScrapeConfigHash)
 }
 
 func (s *scrapeServer) handleGetTargets(_ context.Context, hctx *rpc.HandlerContext) error {
@@ -330,12 +331,12 @@ func (s *scrapeServer) tryGetNewTargetsAndWriteResult(req scrapeRequest) (done b
 			// failure, targets_sent
 			s.sh2.AddCounterHostStringBytes(
 				s.sh2.AggKey(0, format.BuiltinMetricIDAggScrapeTargetDispatch, [format.MaxTags]int32{0, 1, 2}),
-				[]byte(req.addr.String()), 1, 0, nil)
+				[]byte(req.addr.String()), 1, 0, format.BuiltinMetricMetaAggScrapeTargetDispatch)
 		} else {
 			// success, targets_sent
 			s.sh2.AddCounterHostStringBytes(
 				s.sh2.AggKey(0, format.BuiltinMetricIDAggScrapeTargetDispatch, [format.MaxTags]int32{0, 0, 2}),
-				[]byte(req.addr.String()), 1, 0, nil)
+				[]byte(req.addr.String()), 1, 0, format.BuiltinMetricMetaAggScrapeTargetDispatch)
 		}
 	}
 	return true, err

--- a/internal/aggregator/simulator.go
+++ b/internal/aggregator/simulator.go
@@ -158,7 +158,7 @@ func RunSimulator(simID int, metricsStorage *metajournal.MetricsStorage, storage
 }
 
 func generateStats(simID int, journal *metajournal.MetricsStorage, s *agent.Agent, totalRange int, key1range int32, key2range int32, key3range int32) {
-	mag := s.CreateBuiltInItemValue(data_model.Key{Metric: 100, Keys: [16]int32{0, int32(simID)}})
+	mag := s.CreateBuiltInItemValue(data_model.Key{Metric: 100, Keys: [16]int32{0, int32(simID)}}, journal.GetMetaMetric(100))
 
 	metricInfo1 := journal.GetMetaMetricByName(data_model.SimulatorMetricPrefix + "1")
 	metricInfo2 := journal.GetMetaMetricByName(data_model.SimulatorMetricPrefix + "2")

--- a/internal/aggregator/tags_mapper.go
+++ b/internal/aggregator/tags_mapper.go
@@ -63,17 +63,17 @@ func NewTagsMapper(agg *Aggregator, sh2 *agent.Agent, metricStorage *metajournal
 		if err != nil {
 			// TODO - write to actual log from time to time
 			a.appendInternalLog("map_tag", strconv.Itoa(int(extra.AgentEnv)), "error", askedKey, extra.Metric, strconv.Itoa(int(metricID)), strconv.Itoa(int(extra.TagIDKey)), err.Error())
-			ms.sh2.AddValueCounterHost(key, 0, 1, extra.Host)
+			ms.sh2.AddBuiltinValueCounterHost(key, 0, 1, extra.Host)
 		} else {
 			switch c {
 			case format.TagValueIDAggMappingCreatedStatusFlood:
 				// TODO - more efficient flood processing - do not write to log, etc
 				a.appendInternalLog("map_tag", strconv.Itoa(int(extra.AgentEnv)), "flood", askedKey, extra.Metric, strconv.Itoa(int(metricID)), strconv.Itoa(int(extra.TagIDKey)), extra.HostName)
-				ms.sh2.AddValueCounterHost(key, 0, 1, extra.Host)
+				ms.sh2.AddBuiltinValueCounterHost(key, 0, 1, extra.Host)
 			case format.TagValueIDAggMappingCreatedStatusCreated:
 				a.appendInternalLog("map_tag", strconv.Itoa(int(extra.AgentEnv)), "created", askedKey, extra.Metric, strconv.Itoa(int(metricID)), strconv.Itoa(int(extra.TagIDKey)), strconv.Itoa(int(keyValue)))
 				// if askedKey is created, it is valid and safe to write
-				ms.sh2.AddValueCounterHostStringBytes(key, float64(keyValue), 1, extra.Host, []byte(askedKey))
+				ms.sh2.AddBuiltinValueCounterHostStringBytes(key, float64(keyValue), 1, extra.Host, []byte(askedKey))
 			}
 		}
 		return pcache.Int32ToValue(keyValue), d, err
@@ -156,10 +156,10 @@ func (ms *TagsMapper) mapOrFlood(now time.Time, value []byte, metricName string,
 func (ms *TagsMapper) sendCreateTagMappingResult(hctx *rpc.HandlerContext, args tlstatshouse.GetTagMapping2Bytes, r pcache.Result, key data_model.Key) (err error) {
 	if r.Err != nil {
 		key.Keys[5] = format.TagValueIDAggMappingStatusErrUncached
-		ms.sh2.AddCounter(key, 1)
+		ms.sh2.AddBuiltinCounter(key, 1)
 		return r.Err
 	}
-	ms.sh2.AddCounter(key, 1)
+	ms.sh2.AddBuiltinCounter(key, 1)
 	result := tlstatshouse.GetTagMappingResult{Value: pcache.ValueToInt32(r.Value), TtlNanosec: int64(r.TTL)}
 	hctx.Response, err = args.WriteResult(hctx.Response, result)
 	return err

--- a/internal/aggregator/tags_mapper.go
+++ b/internal/aggregator/tags_mapper.go
@@ -63,17 +63,17 @@ func NewTagsMapper(agg *Aggregator, sh2 *agent.Agent, metricStorage *metajournal
 		if err != nil {
 			// TODO - write to actual log from time to time
 			a.appendInternalLog("map_tag", strconv.Itoa(int(extra.AgentEnv)), "error", askedKey, extra.Metric, strconv.Itoa(int(metricID)), strconv.Itoa(int(extra.TagIDKey)), err.Error())
-			ms.sh2.AddBuiltinValueCounterHost(key, 0, 1, extra.Host)
+			ms.sh2.AddValueCounterHost(key, 0, 1, extra.Host, nil)
 		} else {
 			switch c {
 			case format.TagValueIDAggMappingCreatedStatusFlood:
 				// TODO - more efficient flood processing - do not write to log, etc
 				a.appendInternalLog("map_tag", strconv.Itoa(int(extra.AgentEnv)), "flood", askedKey, extra.Metric, strconv.Itoa(int(metricID)), strconv.Itoa(int(extra.TagIDKey)), extra.HostName)
-				ms.sh2.AddBuiltinValueCounterHost(key, 0, 1, extra.Host)
+				ms.sh2.AddValueCounterHost(key, 0, 1, extra.Host, nil)
 			case format.TagValueIDAggMappingCreatedStatusCreated:
 				a.appendInternalLog("map_tag", strconv.Itoa(int(extra.AgentEnv)), "created", askedKey, extra.Metric, strconv.Itoa(int(metricID)), strconv.Itoa(int(extra.TagIDKey)), strconv.Itoa(int(keyValue)))
 				// if askedKey is created, it is valid and safe to write
-				ms.sh2.AddBuiltinValueCounterHostStringBytes(key, float64(keyValue), 1, extra.Host, []byte(askedKey))
+				ms.sh2.AddValueCounterHostStringBytes(key, float64(keyValue), 1, extra.Host, []byte(askedKey), nil)
 			}
 		}
 		return pcache.Int32ToValue(keyValue), d, err
@@ -156,10 +156,10 @@ func (ms *TagsMapper) mapOrFlood(now time.Time, value []byte, metricName string,
 func (ms *TagsMapper) sendCreateTagMappingResult(hctx *rpc.HandlerContext, args tlstatshouse.GetTagMapping2Bytes, r pcache.Result, key data_model.Key) (err error) {
 	if r.Err != nil {
 		key.Keys[5] = format.TagValueIDAggMappingStatusErrUncached
-		ms.sh2.AddBuiltinCounter(key, 1)
+		ms.sh2.AddCounter(key, 1, nil)
 		return r.Err
 	}
-	ms.sh2.AddBuiltinCounter(key, 1)
+	ms.sh2.AddCounter(key, 1, nil)
 	result := tlstatshouse.GetTagMappingResult{Value: pcache.ValueToInt32(r.Value), TtlNanosec: int64(r.TTL)}
 	hctx.Response, err = args.WriteResult(hctx.Response, result)
 	return err

--- a/internal/api/handler_easyjson.go
+++ b/internal/api/handler_easyjson.go
@@ -504,6 +504,8 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat(in *jlexer.Lex
 				}
 				in.Delim(']')
 			}
+		case "sharding":
+			easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat2(in, &out.Sharding)
 		default:
 			in.SkipRecursive()
 		}
@@ -659,6 +661,67 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat(out *jwriter.W
 			}
 			out.RawByte(']')
 		}
+	}
+	if true {
+		const prefix string = ",\"sharding\":"
+		out.RawString(prefix)
+		easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat2(out, in.Sharding)
+	}
+	out.RawByte('}')
+}
+func easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat2(in *jlexer.Lexer, out *format.MetricSharding) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "strategy":
+			out.Strategy = string(in.String())
+		case "shard":
+			(out.Shard).UnmarshalEasyJSON(in)
+		case "tag_id":
+			(out.TagId).UnmarshalEasyJSON(in)
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat2(out *jwriter.Writer, in format.MetricSharding) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"strategy\":"
+		out.RawString(prefix[1:])
+		out.String(string(in.Strategy))
+	}
+	if (in.Shard).IsDefined() {
+		const prefix string = ",\"shard\":"
+		out.RawString(prefix)
+		(in.Shard).MarshalEasyJSON(out)
+	}
+	if (in.TagId).IsDefined() {
+		const prefix string = ",\"tag_id\":"
+		out.RawString(prefix)
+		(in.TagId).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }
@@ -1202,7 +1265,7 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi5(in *jlexer.Lexer
 		}
 		switch key {
 		case "namespace":
-			easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat2(in, &out.Namespace)
+			easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat3(in, &out.Namespace)
 		default:
 			in.SkipRecursive()
 		}
@@ -1220,7 +1283,7 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi5(out *jwriter.Wri
 	{
 		const prefix string = ",\"namespace\":"
 		out.RawString(prefix[1:])
-		easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat2(out, in.Namespace)
+		easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat3(out, in.Namespace)
 	}
 	out.RawByte('}')
 }
@@ -1234,7 +1297,7 @@ func (v NamespaceInfo) MarshalEasyJSON(w *jwriter.Writer) {
 func (v *NamespaceInfo) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi5(l, v)
 }
-func easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat2(in *jlexer.Lexer, out *format.NamespaceMeta) {
+func easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat3(in *jlexer.Lexer, out *format.NamespaceMeta) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1277,7 +1340,7 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat2(in *jlexer.Le
 		in.Consumed()
 	}
 }
-func easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat2(out *jwriter.Writer, in format.NamespaceMeta) {
+func easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat3(out *jwriter.Writer, in format.NamespaceMeta) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1338,7 +1401,7 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi6(in *jlexer.Lexer
 		}
 		switch key {
 		case "group":
-			easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat3(in, &out.Group)
+			easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat4(in, &out.Group)
 		case "metrics":
 			if in.IsNull() {
 				in.Skip()
@@ -1379,7 +1442,7 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi6(out *jwriter.Wri
 	{
 		const prefix string = ",\"group\":"
 		out.RawString(prefix[1:])
-		easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat3(out, in.Group)
+		easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat4(out, in.Group)
 	}
 	{
 		const prefix string = ",\"metrics\":"
@@ -1409,7 +1472,7 @@ func (v MetricsGroupInfo) MarshalEasyJSON(w *jwriter.Writer) {
 func (v *MetricsGroupInfo) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi6(l, v)
 }
-func easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat3(in *jlexer.Lexer, out *format.MetricsGroup) {
+func easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat4(in *jlexer.Lexer, out *format.MetricsGroup) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1452,7 +1515,7 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat3(in *jlexer.Le
 		in.Consumed()
 	}
 }
-func easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat3(out *jwriter.Writer, in format.MetricsGroup) {
+func easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat4(out *jwriter.Writer, in format.MetricsGroup) {
 	out.RawByte('{')
 	first := true
 	_ = first

--- a/internal/api/handler_easyjson.go
+++ b/internal/api/handler_easyjson.go
@@ -9,6 +9,7 @@ import (
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	jwriter "github.com/mailru/easyjson/jwriter"
+
 	format "github.com/vkcom/statshouse/internal/format"
 )
 
@@ -505,7 +506,28 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat(in *jlexer.Lex
 				in.Delim(']')
 			}
 		case "sharding":
-			easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat2(in, &out.Sharding)
+			if in.IsNull() {
+				in.Skip()
+				out.Sharding = nil
+			} else {
+				in.Delim('[')
+				if out.Sharding == nil {
+					if !in.IsDelim(']') {
+						out.Sharding = make([]format.MetricSharding, 0, 1)
+					} else {
+						out.Sharding = []format.MetricSharding{}
+					}
+				} else {
+					out.Sharding = (out.Sharding)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v12 format.MetricSharding
+					easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat2(in, &v12)
+					out.Sharding = append(out.Sharding, v12)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -555,11 +577,11 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat(out *jwriter.W
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v12, v13 := range in.Tags {
-				if v12 > 0 {
+			for v13, v14 := range in.Tags {
+				if v13 > 0 {
 					out.RawByte(',')
 				}
-				easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat1(out, v13)
+				easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat1(out, v14)
 			}
 			out.RawByte(']')
 		}
@@ -569,16 +591,16 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat(out *jwriter.W
 		out.RawString(prefix)
 		{
 			out.RawByte('{')
-			v14First := true
-			for v14Name, v14Value := range in.TagsDraft {
-				if v14First {
-					v14First = false
+			v15First := true
+			for v15Name, v15Value := range in.TagsDraft {
+				if v15First {
+					v15First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v14Name))
+				out.String(string(v15Name))
 				out.RawByte(':')
-				easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat1(out, v14Value)
+				easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat1(out, v15Value)
 			}
 			out.RawByte('}')
 		}
@@ -653,19 +675,28 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat(out *jwriter.W
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v15, v16 := range in.FairKeyTagIDs {
-				if v15 > 0 {
+			for v16, v17 := range in.FairKeyTagIDs {
+				if v16 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v16))
+				out.String(string(v17))
 			}
 			out.RawByte(']')
 		}
 	}
-	if true {
+	if len(in.Sharding) != 0 {
 		const prefix string = ",\"sharding\":"
 		out.RawString(prefix)
-		easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat2(out, in.Sharding)
+		{
+			out.RawByte('[')
+			for v18, v19 := range in.Sharding {
+				if v18 > 0 {
+					out.RawByte(',')
+				}
+				easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat2(out, v19)
+			}
+			out.RawByte(']')
+		}
 	}
 	out.RawByte('}')
 }
@@ -694,6 +725,8 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat2(in *jlexer.Le
 			(out.Shard).UnmarshalEasyJSON(in)
 		case "tag_id":
 			(out.TagId).UnmarshalEasyJSON(in)
+		case "after_ts":
+			(out.AfterTs).UnmarshalEasyJSON(in)
 		default:
 			in.SkipRecursive()
 		}
@@ -722,6 +755,11 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat2(out *jwriter.
 		const prefix string = ",\"tag_id\":"
 		out.RawString(prefix)
 		(in.TagId).MarshalEasyJSON(out)
+	}
+	if (in.AfterTs).IsDefined() {
+		const prefix string = ",\"after_ts\":"
+		out.RawString(prefix)
+		(in.AfterTs).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }
@@ -765,9 +803,9 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat1(in *jlexer.Le
 				for !in.IsDelim('}') {
 					key := int32(in.Int32Str())
 					in.WantColon()
-					var v17 string
-					v17 = string(in.String())
-					(out.ID2Value)[key] = v17
+					var v20 string
+					v20 = string(in.String())
+					(out.ID2Value)[key] = v20
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -785,9 +823,9 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalFormat1(in *jlexer.Le
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v18 string
-					v18 = string(in.String())
-					(out.ValueComments)[key] = v18
+					var v21 string
+					v21 = string(in.String())
+					(out.ValueComments)[key] = v21
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -852,16 +890,16 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat1(out *jwriter.
 		}
 		{
 			out.RawByte('{')
-			v19First := true
-			for v19Name, v19Value := range in.ID2Value {
-				if v19First {
-					v19First = false
+			v22First := true
+			for v22Name, v22Value := range in.ID2Value {
+				if v22First {
+					v22First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.Int32Str(int32(v19Name))
+				out.Int32Str(int32(v22Name))
 				out.RawByte(':')
-				out.String(string(v19Value))
+				out.String(string(v22Value))
 			}
 			out.RawByte('}')
 		}
@@ -876,16 +914,16 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalFormat1(out *jwriter.
 		}
 		{
 			out.RawByte('{')
-			v20First := true
-			for v20Name, v20Value := range in.ValueComments {
-				if v20First {
-					v20First = false
+			v23First := true
+			for v23Name, v23Value := range in.ValueComments {
+				if v23First {
+					v23First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v20Name))
+				out.String(string(v23Name))
 				out.RawByte(':')
-				out.String(string(v20Value))
+				out.String(string(v23Value))
 			}
 			out.RawByte('}')
 		}
@@ -927,9 +965,9 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi3(in *jlexer.Lexer
 					out.Time = (out.Time)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v21 int64
-					v21 = int64(in.Int64())
-					out.Time = append(out.Time, v21)
+					var v24 int64
+					v24 = int64(in.Int64())
+					out.Time = append(out.Time, v24)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -950,9 +988,9 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi3(in *jlexer.Lexer
 					out.SeriesMeta = (out.SeriesMeta)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v22 QuerySeriesMetaV2
-					easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi4(in, &v22)
-					out.SeriesMeta = append(out.SeriesMeta, v22)
+					var v25 QuerySeriesMetaV2
+					easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi4(in, &v25)
+					out.SeriesMeta = append(out.SeriesMeta, v25)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -973,38 +1011,38 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi3(in *jlexer.Lexer
 					out.SeriesData = (out.SeriesData)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v23 *[]float64
+					var v26 *[]float64
 					if in.IsNull() {
 						in.Skip()
-						v23 = nil
+						v26 = nil
 					} else {
-						if v23 == nil {
-							v23 = new([]float64)
+						if v26 == nil {
+							v26 = new([]float64)
 						}
 						if in.IsNull() {
 							in.Skip()
-							*v23 = nil
+							*v26 = nil
 						} else {
 							in.Delim('[')
-							if *v23 == nil {
+							if *v26 == nil {
 								if !in.IsDelim(']') {
-									*v23 = make([]float64, 0, 8)
+									*v26 = make([]float64, 0, 8)
 								} else {
-									*v23 = []float64{}
+									*v26 = []float64{}
 								}
 							} else {
-								*v23 = (*v23)[:0]
+								*v26 = (*v26)[:0]
 							}
 							for !in.IsDelim(']') {
-								var v24 float64
-								v24 = float64(in.Float64())
-								*v23 = append(*v23, v24)
+								var v27 float64
+								v27 = float64(in.Float64())
+								*v26 = append(*v26, v27)
 								in.WantComma()
 							}
 							in.Delim(']')
 						}
 					}
-					out.SeriesData = append(out.SeriesData, v23)
+					out.SeriesData = append(out.SeriesData, v26)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1030,11 +1068,11 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi3(out *jwriter.Wri
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v25, v26 := range in.Time {
-				if v25 > 0 {
+			for v28, v29 := range in.Time {
+				if v28 > 0 {
 					out.RawByte(',')
 				}
-				out.Int64(int64(v26))
+				out.Int64(int64(v29))
 			}
 			out.RawByte(']')
 		}
@@ -1046,11 +1084,11 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi3(out *jwriter.Wri
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v27, v28 := range in.SeriesMeta {
-				if v27 > 0 {
+			for v30, v31 := range in.SeriesMeta {
+				if v30 > 0 {
 					out.RawByte(',')
 				}
-				easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi4(out, v28)
+				easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi4(out, v31)
 			}
 			out.RawByte(']')
 		}
@@ -1062,25 +1100,25 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi3(out *jwriter.Wri
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v29, v30 := range in.SeriesData {
-				if v29 > 0 {
+			for v32, v33 := range in.SeriesData {
+				if v32 > 0 {
 					out.RawByte(',')
 				}
-				if v30 == nil {
+				if v33 == nil {
 					out.RawString("null")
 				} else {
-					if *v30 == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+					if *v33 == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 						out.RawString("null")
 					} else {
 						out.RawByte('[')
-						for v31, v32 := range *v30 {
-							if v31 > 0 {
+						for v34, v35 := range *v33 {
+							if v34 > 0 {
 								out.RawByte(',')
 							}
-							if math.IsNaN(float64(v32)) {
+							if math.IsNaN(float64(v35)) {
 								out.RawString("null")
 							} else {
-								out.Float64(float64(v32))
+								out.Float64(float64(v35))
 							}
 						}
 						out.RawByte(']')
@@ -1122,9 +1160,9 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi4(in *jlexer.Lexer
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v33 SeriesMetaTag
-					easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi1(in, &v33)
-					(out.Tags)[key] = v33
+					var v36 SeriesMetaTag
+					easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi1(in, &v36)
+					(out.Tags)[key] = v36
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -1145,9 +1183,9 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi4(in *jlexer.Lexer
 					out.MaxHosts = (out.MaxHosts)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v34 string
-					v34 = string(in.String())
-					out.MaxHosts = append(out.MaxHosts, v34)
+					var v37 string
+					v37 = string(in.String())
+					out.MaxHosts = append(out.MaxHosts, v37)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1188,16 +1226,16 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi4(out *jwriter.Wri
 			out.RawString(`null`)
 		} else {
 			out.RawByte('{')
-			v35First := true
-			for v35Name, v35Value := range in.Tags {
-				if v35First {
-					v35First = false
+			v38First := true
+			for v38Name, v38Value := range in.Tags {
+				if v38First {
+					v38First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v35Name))
+				out.String(string(v38Name))
 				out.RawByte(':')
-				easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi1(out, v35Value)
+				easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi1(out, v38Value)
 			}
 			out.RawByte('}')
 		}
@@ -1209,11 +1247,11 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi4(out *jwriter.Wri
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v36, v37 := range in.MaxHosts {
-				if v36 > 0 {
+			for v39, v40 := range in.MaxHosts {
+				if v39 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v37))
+				out.String(string(v40))
 			}
 			out.RawByte(']')
 		}
@@ -1418,9 +1456,9 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi6(in *jlexer.Lexer
 					out.Metrics = (out.Metrics)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v38 string
-					v38 = string(in.String())
-					out.Metrics = append(out.Metrics, v38)
+					var v41 string
+					v41 = string(in.String())
+					out.Metrics = append(out.Metrics, v41)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1451,11 +1489,11 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi6(out *jwriter.Wri
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v39, v40 := range in.Metrics {
-				if v39 > 0 {
+			for v42, v43 := range in.Metrics {
+				if v42 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v40))
+				out.String(string(v43))
 			}
 			out.RawByte(']')
 		}
@@ -1643,9 +1681,9 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi8(in *jlexer.Lexer
 					out.Rows = (out.Rows)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v41 queryTableRow
-					(v41).UnmarshalEasyJSON(in)
-					out.Rows = append(out.Rows, v41)
+					var v44 queryTableRow
+					(v44).UnmarshalEasyJSON(in)
+					out.Rows = append(out.Rows, v44)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1666,9 +1704,9 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi8(in *jlexer.Lexer
 					out.What = (out.What)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v42 QueryFunc
-					(v42).UnmarshalEasyJSON(in)
-					out.What = append(out.What, v42)
+					var v45 QueryFunc
+					(v45).UnmarshalEasyJSON(in)
+					out.What = append(out.What, v45)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1695,9 +1733,9 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi8(in *jlexer.Lexer
 					out.DebugQueries = (out.DebugQueries)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v43 string
-					v43 = string(in.String())
-					out.DebugQueries = append(out.DebugQueries, v43)
+					var v46 string
+					v46 = string(in.String())
+					out.DebugQueries = append(out.DebugQueries, v46)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1723,11 +1761,11 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi8(out *jwriter.Wri
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v44, v45 := range in.Rows {
-				if v44 > 0 {
+			for v47, v48 := range in.Rows {
+				if v47 > 0 {
 					out.RawByte(',')
 				}
-				(v45).MarshalEasyJSON(out)
+				(v48).MarshalEasyJSON(out)
 			}
 			out.RawByte(']')
 		}
@@ -1739,11 +1777,11 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi8(out *jwriter.Wri
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v46, v47 := range in.What {
-				if v46 > 0 {
+			for v49, v50 := range in.What {
+				if v49 > 0 {
 					out.RawByte(',')
 				}
-				(v47).MarshalEasyJSON(out)
+				(v50).MarshalEasyJSON(out)
 			}
 			out.RawByte(']')
 		}
@@ -1770,11 +1808,11 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi8(out *jwriter.Wri
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v48, v49 := range in.DebugQueries {
-				if v48 > 0 {
+			for v51, v52 := range in.DebugQueries {
+				if v51 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v49))
+				out.String(string(v52))
 			}
 			out.RawByte(']')
 		}
@@ -1826,9 +1864,9 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi9(in *jlexer.Lexer
 					out.PointMeta = (out.PointMeta)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v50 QueryPointsMeta
-					easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi10(in, &v50)
-					out.PointMeta = append(out.PointMeta, v50)
+					var v53 QueryPointsMeta
+					easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi10(in, &v53)
+					out.PointMeta = append(out.PointMeta, v53)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1849,9 +1887,9 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi9(in *jlexer.Lexer
 					out.PointData = (out.PointData)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v51 float64
-					v51 = float64(in.Float64())
-					out.PointData = append(out.PointData, v51)
+					var v54 float64
+					v54 = float64(in.Float64())
+					out.PointData = append(out.PointData, v54)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1872,9 +1910,9 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi9(in *jlexer.Lexer
 					out.DebugQueries = (out.DebugQueries)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v52 string
-					v52 = string(in.String())
-					out.DebugQueries = append(out.DebugQueries, v52)
+					var v55 string
+					v55 = string(in.String())
+					out.DebugQueries = append(out.DebugQueries, v55)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1900,11 +1938,11 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi9(out *jwriter.Wri
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v53, v54 := range in.PointMeta {
-				if v53 > 0 {
+			for v56, v57 := range in.PointMeta {
+				if v56 > 0 {
 					out.RawByte(',')
 				}
-				easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi10(out, v54)
+				easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi10(out, v57)
 			}
 			out.RawByte(']')
 		}
@@ -1916,15 +1954,16 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi9(out *jwriter.Wri
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v55, v56 := range in.PointData {
-				if v55 > 0 {
+			for v58, v59 := range in.PointData {
+				if v58 > 0 {
 					out.RawByte(',')
 				}
-				if math.IsNaN(float64(v56)) {
+				if math.IsNaN(v59) {
 					out.RawString("null")
 				} else {
-					out.Float64(float64(v56))
-				}			}
+					out.Float64(float64(v59))
+				}
+			}
 			out.RawByte(']')
 		}
 	}
@@ -1935,11 +1974,11 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi9(out *jwriter.Wri
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v57, v58 := range in.DebugQueries {
-				if v57 > 0 {
+			for v60, v61 := range in.DebugQueries {
+				if v60 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v58))
+				out.String(string(v61))
 			}
 			out.RawByte(']')
 		}
@@ -1986,9 +2025,9 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi10(in *jlexer.Lexe
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v59 SeriesMetaTag
-					easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi1(in, &v59)
-					(out.Tags)[key] = v59
+					var v62 SeriesMetaTag
+					easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi1(in, &v62)
+					(out.Tags)[key] = v62
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -2029,16 +2068,16 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi10(out *jwriter.Wr
 			out.RawString(`null`)
 		} else {
 			out.RawByte('{')
-			v60First := true
-			for v60Name, v60Value := range in.Tags {
-				if v60First {
-					v60First = false
+			v63First := true
+			for v63Name, v63Value := range in.Tags {
+				if v63First {
+					v63First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v60Name))
+				out.String(string(v63Name))
 				out.RawByte(':')
-				easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi1(out, v60Value)
+				easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi1(out, v63Value)
 			}
 			out.RawByte('}')
 		}
@@ -2105,9 +2144,9 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi11(in *jlexer.Lexe
 					out.Namespaces = (out.Namespaces)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v61 namespaceShortInfo
-					easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi12(in, &v61)
-					out.Namespaces = append(out.Namespaces, v61)
+					var v64 namespaceShortInfo
+					easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi12(in, &v64)
+					out.Namespaces = append(out.Namespaces, v64)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2133,11 +2172,11 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi11(out *jwriter.Wr
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v62, v63 := range in.Namespaces {
-				if v62 > 0 {
+			for v65, v66 := range in.Namespaces {
+				if v65 > 0 {
 					out.RawByte(',')
 				}
-				easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi12(out, v63)
+				easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi12(out, v66)
 			}
 			out.RawByte(']')
 		}
@@ -2245,9 +2284,9 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi13(in *jlexer.Lexe
 					out.Metrics = (out.Metrics)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v64 metricShortInfo
-					easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi14(in, &v64)
-					out.Metrics = append(out.Metrics, v64)
+					var v67 metricShortInfo
+					easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi14(in, &v67)
+					out.Metrics = append(out.Metrics, v67)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2273,11 +2312,11 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi13(out *jwriter.Wr
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v65, v66 := range in.Metrics {
-				if v65 > 0 {
+			for v68, v69 := range in.Metrics {
+				if v68 > 0 {
 					out.RawByte(',')
 				}
-				easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi14(out, v66)
+				easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi14(out, v69)
 			}
 			out.RawByte(']')
 		}
@@ -2371,9 +2410,9 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi15(in *jlexer.Lexe
 					out.TagValues = (out.TagValues)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v67 MetricTagValueInfo
-					easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi16(in, &v67)
-					out.TagValues = append(out.TagValues, v67)
+					var v70 MetricTagValueInfo
+					easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi16(in, &v70)
+					out.TagValues = append(out.TagValues, v70)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2401,11 +2440,11 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi15(out *jwriter.Wr
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v68, v69 := range in.TagValues {
-				if v68 > 0 {
+			for v71, v72 := range in.TagValues {
+				if v71 > 0 {
 					out.RawByte(',')
 				}
-				easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi16(out, v69)
+				easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi16(out, v72)
 			}
 			out.RawByte(']')
 		}
@@ -2511,9 +2550,9 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi17(in *jlexer.Lexe
 					out.Groups = (out.Groups)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v70 groupShortInfo
-					easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi18(in, &v70)
-					out.Groups = append(out.Groups, v70)
+					var v73 groupShortInfo
+					easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi18(in, &v73)
+					out.Groups = append(out.Groups, v73)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2539,11 +2578,11 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi17(out *jwriter.Wr
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v71, v72 := range in.Groups {
-				if v71 > 0 {
+			for v74, v75 := range in.Groups {
+				if v74 > 0 {
 					out.RawByte(',')
 				}
-				easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi18(out, v72)
+				easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi18(out, v75)
 			}
 			out.RawByte(']')
 		}
@@ -2658,9 +2697,9 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi19(in *jlexer.Lexe
 					out.Dashboards = (out.Dashboards)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v73 dashboardShortInfo
-					easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi20(in, &v73)
-					out.Dashboards = append(out.Dashboards, v73)
+					var v76 dashboardShortInfo
+					easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi20(in, &v76)
+					out.Dashboards = append(out.Dashboards, v76)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2686,11 +2725,11 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi19(out *jwriter.Wr
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v74, v75 := range in.Dashboards {
-				if v74 > 0 {
+			for v77, v78 := range in.Dashboards {
+				if v77 > 0 {
 					out.RawByte(',')
 				}
-				easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi20(out, v75)
+				easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi20(out, v78)
 			}
 			out.RawByte(']')
 		}
@@ -2862,15 +2901,15 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi22(in *jlexer.Lexe
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v76 interface{}
-					if m, ok := v76.(easyjson.Unmarshaler); ok {
+					var v79 interface{}
+					if m, ok := v79.(easyjson.Unmarshaler); ok {
 						m.UnmarshalEasyJSON(in)
-					} else if m, ok := v76.(json.Unmarshaler); ok {
+					} else if m, ok := v79.(json.Unmarshaler); ok {
 						_ = m.UnmarshalJSON(in.Raw())
 					} else {
-						v76 = in.Interface()
+						v79 = in.Interface()
 					}
-					(out.JSONData)[key] = v76
+					(out.JSONData)[key] = v79
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -2926,21 +2965,21 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi22(out *jwriter.Wr
 			out.RawString(`null`)
 		} else {
 			out.RawByte('{')
-			v77First := true
-			for v77Name, v77Value := range in.JSONData {
-				if v77First {
-					v77First = false
+			v80First := true
+			for v80Name, v80Value := range in.JSONData {
+				if v80First {
+					v80First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v77Name))
+				out.String(string(v80Name))
 				out.RawByte(':')
-				if m, ok := v77Value.(easyjson.Marshaler); ok {
+				if m, ok := v80Value.(easyjson.Marshaler); ok {
 					m.MarshalEasyJSON(out)
-				} else if m, ok := v77Value.(json.Marshaler); ok {
+				} else if m, ok := v80Value.(json.Marshaler); ok {
 					out.Raw(m.MarshalJSON())
 				} else {
-					out.Raw(json.Marshal(v77Value))
+					out.Raw(json.Marshal(v80Value))
 				}
 			}
 			out.RawByte('}')
@@ -2983,9 +3022,9 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi23(in *jlexer.Lexe
 					out.Plots = (out.Plots)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v78 DashboardPlot
-					easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi24(in, &v78)
-					out.Plots = append(out.Plots, v78)
+					var v81 DashboardPlot
+					easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi24(in, &v81)
+					out.Plots = append(out.Plots, v81)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3006,9 +3045,9 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi23(in *jlexer.Lexe
 					out.Vars = (out.Vars)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v79 DashboardVar
-					easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi25(in, &v79)
-					out.Vars = append(out.Vars, v79)
+					var v82 DashboardVar
+					easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi25(in, &v82)
+					out.Vars = append(out.Vars, v82)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3044,11 +3083,11 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi23(out *jwriter.Wr
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v80, v81 := range in.Plots {
-				if v80 > 0 {
+			for v83, v84 := range in.Plots {
+				if v83 > 0 {
 					out.RawByte(',')
 				}
-				easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi24(out, v81)
+				easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi24(out, v84)
 			}
 			out.RawByte(']')
 		}
@@ -3060,11 +3099,11 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi23(out *jwriter.Wr
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v82, v83 := range in.Vars {
-				if v82 > 0 {
+			for v85, v86 := range in.Vars {
+				if v85 > 0 {
 					out.RawByte(',')
 				}
-				easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi25(out, v83)
+				easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi25(out, v86)
 			}
 			out.RawByte(']')
 		}
@@ -3086,11 +3125,11 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi23(out *jwriter.Wr
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v84, v85 := range in.TimeShifts {
-				if v84 > 0 {
+			for v87, v88 := range in.TimeShifts {
+				if v87 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v85))
+				out.String(string(v88))
 			}
 			out.RawByte(']')
 		}
@@ -3195,9 +3234,9 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi25(in *jlexer.Lexe
 					out.Vals = (out.Vals)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v86 string
-					v86 = string(in.String())
-					out.Vals = append(out.Vals, v86)
+					var v89 string
+					v89 = string(in.String())
+					out.Vals = append(out.Vals, v89)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3218,30 +3257,30 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi25(in *jlexer.Lexe
 					out.Link = (out.Link)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v87 []int
+					var v90 []int
 					if in.IsNull() {
 						in.Skip()
-						v87 = nil
+						v90 = nil
 					} else {
 						in.Delim('[')
-						if v87 == nil {
+						if v90 == nil {
 							if !in.IsDelim(']') {
-								v87 = make([]int, 0, 8)
+								v90 = make([]int, 0, 8)
 							} else {
-								v87 = []int{}
+								v90 = []int{}
 							}
 						} else {
-							v87 = (v87)[:0]
+							v90 = (v90)[:0]
 						}
 						for !in.IsDelim(']') {
-							var v88 int
-							v88 = int(in.Int())
-							v87 = append(v87, v88)
+							var v91 int
+							v91 = int(in.Int())
+							v90 = append(v90, v91)
 							in.WantComma()
 						}
 						in.Delim(']')
 					}
-					out.Link = append(out.Link, v87)
+					out.Link = append(out.Link, v90)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3277,11 +3316,11 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi25(out *jwriter.Wr
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v89, v90 := range in.Vals {
-				if v89 > 0 {
+			for v92, v93 := range in.Vals {
+				if v92 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v90))
+				out.String(string(v93))
 			}
 			out.RawByte(']')
 		}
@@ -3293,19 +3332,19 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi25(out *jwriter.Wr
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v91, v92 := range in.Link {
-				if v91 > 0 {
+			for v94, v95 := range in.Link {
+				if v94 > 0 {
 					out.RawByte(',')
 				}
-				if v92 == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+				if v95 == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 					out.RawString("null")
 				} else {
 					out.RawByte('[')
-					for v93, v94 := range v92 {
-						if v93 > 0 {
+					for v96, v97 := range v95 {
+						if v96 > 0 {
 							out.RawByte(',')
 						}
-						out.Int(int(v94))
+						out.Int(int(v97))
 					}
 					out.RawByte(']')
 				}
@@ -3411,9 +3450,9 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi24(in *jlexer.Lexe
 					out.What = (out.What)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v95 string
-					v95 = string(in.String())
-					out.What = append(out.What, v95)
+					var v98 string
+					v98 = string(in.String())
+					out.What = append(out.What, v98)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3434,9 +3473,9 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi24(in *jlexer.Lexe
 					out.GroupBy = (out.GroupBy)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v96 string
-					v96 = string(in.String())
-					out.GroupBy = append(out.GroupBy, v96)
+					var v99 string
+					v99 = string(in.String())
+					out.GroupBy = append(out.GroupBy, v99)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3450,30 +3489,30 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi24(in *jlexer.Lexe
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v97 []string
+					var v100 []string
 					if in.IsNull() {
 						in.Skip()
-						v97 = nil
+						v100 = nil
 					} else {
 						in.Delim('[')
-						if v97 == nil {
+						if v100 == nil {
 							if !in.IsDelim(']') {
-								v97 = make([]string, 0, 4)
+								v100 = make([]string, 0, 4)
 							} else {
-								v97 = []string{}
+								v100 = []string{}
 							}
 						} else {
-							v97 = (v97)[:0]
+							v100 = (v100)[:0]
 						}
 						for !in.IsDelim(']') {
-							var v98 string
-							v98 = string(in.String())
-							v97 = append(v97, v98)
+							var v101 string
+							v101 = string(in.String())
+							v100 = append(v100, v101)
 							in.WantComma()
 						}
 						in.Delim(']')
 					}
-					(out.FilterIn)[key] = v97
+					(out.FilterIn)[key] = v100
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -3487,30 +3526,30 @@ func easyjson888c126aDecodeGithubComVkcomStatshouseInternalApi24(in *jlexer.Lexe
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v99 []string
+					var v102 []string
 					if in.IsNull() {
 						in.Skip()
-						v99 = nil
+						v102 = nil
 					} else {
 						in.Delim('[')
-						if v99 == nil {
+						if v102 == nil {
 							if !in.IsDelim(']') {
-								v99 = make([]string, 0, 4)
+								v102 = make([]string, 0, 4)
 							} else {
-								v99 = []string{}
+								v102 = []string{}
 							}
 						} else {
-							v99 = (v99)[:0]
+							v102 = (v102)[:0]
 						}
 						for !in.IsDelim(']') {
-							var v100 string
-							v100 = string(in.String())
-							v99 = append(v99, v100)
+							var v103 string
+							v103 = string(in.String())
+							v102 = append(v102, v103)
 							in.WantComma()
 						}
 						in.Delim(']')
 					}
-					(out.FilterNotIn)[key] = v99
+					(out.FilterNotIn)[key] = v102
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -3570,11 +3609,11 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi24(out *jwriter.Wr
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v101, v102 := range in.What {
-				if v101 > 0 {
+			for v104, v105 := range in.What {
+				if v104 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v102))
+				out.String(string(v105))
 			}
 			out.RawByte(']')
 		}
@@ -3586,11 +3625,11 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi24(out *jwriter.Wr
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v103, v104 := range in.GroupBy {
-				if v103 > 0 {
+			for v106, v107 := range in.GroupBy {
+				if v106 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v104))
+				out.String(string(v107))
 			}
 			out.RawByte(']')
 		}
@@ -3602,40 +3641,8 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi24(out *jwriter.Wr
 			out.RawString(`null`)
 		} else {
 			out.RawByte('{')
-			v105First := true
-			for v105Name, v105Value := range in.FilterIn {
-				if v105First {
-					v105First = false
-				} else {
-					out.RawByte(',')
-				}
-				out.String(string(v105Name))
-				out.RawByte(':')
-				if v105Value == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
-					out.RawString("null")
-				} else {
-					out.RawByte('[')
-					for v106, v107 := range v105Value {
-						if v106 > 0 {
-							out.RawByte(',')
-						}
-						out.String(string(v107))
-					}
-					out.RawByte(']')
-				}
-			}
-			out.RawByte('}')
-		}
-	}
-	{
-		const prefix string = ",\"filterNotIn\":"
-		out.RawString(prefix)
-		if in.FilterNotIn == nil && (out.Flags&jwriter.NilMapAsEmpty) == 0 {
-			out.RawString(`null`)
-		} else {
-			out.RawByte('{')
 			v108First := true
-			for v108Name, v108Value := range in.FilterNotIn {
+			for v108Name, v108Value := range in.FilterIn {
 				if v108First {
 					v108First = false
 				} else {
@@ -3652,6 +3659,38 @@ func easyjson888c126aEncodeGithubComVkcomStatshouseInternalApi24(out *jwriter.Wr
 							out.RawByte(',')
 						}
 						out.String(string(v110))
+					}
+					out.RawByte(']')
+				}
+			}
+			out.RawByte('}')
+		}
+	}
+	{
+		const prefix string = ",\"filterNotIn\":"
+		out.RawString(prefix)
+		if in.FilterNotIn == nil && (out.Flags&jwriter.NilMapAsEmpty) == 0 {
+			out.RawString(`null`)
+		} else {
+			out.RawByte('{')
+			v111First := true
+			for v111Name, v111Value := range in.FilterNotIn {
+				if v111First {
+					v111First = false
+				} else {
+					out.RawByte(',')
+				}
+				out.String(string(v111Name))
+				out.RawByte(':')
+				if v111Value == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+					out.RawString("null")
+				} else {
+					out.RawByte('[')
+					for v112, v113 := range v111Value {
+						if v112 > 0 {
+							out.RawByte(',')
+						}
+						out.String(string(v113))
 					}
 					out.RawByte(']')
 				}

--- a/internal/data_model/schema.tl
+++ b/internal/data_model/schema.tl
@@ -168,9 +168,8 @@ statshouse.shutdownInfo#4124cf9c
     queue_size_disk_sum_unsent:fields_mask.3?int
     original_size:#
     compressed_data:string
-    // 0 - shard by 16 mapped tags
-    // 1 - shard by metric id
-    sharding:fields_mask.5?int = String;
+    sharding:fields_mask.5?int // deprecated because sharding is now configured for each metric separately
+    = String;
 
 @readwrite statshouse.sendKeepAlive2#4285ff53
     fields_mask:#

--- a/internal/format/builtin.go
+++ b/internal/format/builtin.go
@@ -2667,6 +2667,7 @@ func init() {
 		v.Resolution = 5
 		v.GroupID = BuiltinGroupIDHost
 		v.Group = BuiltInGroupDefault[BuiltinGroupIDHost]
+		v.Sharding = []MetricSharding{{Strategy: ShardByMetricId}}
 		BuiltinMetrics[k] = v
 		builtinMetricsAllowedToReceive[k] = true
 		metricsWithoutAggregatorID[k] = true

--- a/internal/format/builtin.go
+++ b/internal/format/builtin.go
@@ -278,6 +278,7 @@ const (
 	TagValueIDSrcIngestionStatusWarnOldCounterSemantic       = 51 // never written, for historic data
 	TagValueIDSrcIngestionStatusWarnMapInvalidRawTagValue    = 52
 	TagValueIDSrcIngestionStatusWarnMapTagNameFoundDraft     = 53
+	TagValueIDSrcIngestionStatusErrShardingFailed            = 54
 
 	TagValueIDPacketFormatLegacy   = 1
 	TagValueIDPacketFormatTL       = 2
@@ -685,6 +686,7 @@ This metric uses sampling budgets of metric it refers to, so flooding by errors 
 					TagValueIDSrcIngestionStatusWarnOldCounterSemantic:       "warn_deprecated_counter_semantic",
 					TagValueIDSrcIngestionStatusWarnMapInvalidRawTagValue:    "warn_map_invalid_raw_tag_value",
 					TagValueIDSrcIngestionStatusWarnMapTagNameFoundDraft:     "warn_tag_draft_found",
+					TagValueIDSrcIngestionStatusErrShardingFailed:            "err_sharding_failed",
 				}),
 			}, {
 				Description: "tag_id",

--- a/internal/format/builtin.go
+++ b/internal/format/builtin.go
@@ -119,21 +119,21 @@ const (
 	BuiltinMetricIDAggSamplingTime            = -95
 	BuiltinMetricIDAgentDiskCacheSize         = -96
 	BuiltinMetricIDAggContributors            = -97
-	BuiltinMetricIDAggAgentSharding           = -98
-	BuiltinMetricIDAPICacheBytesAlloc         = -99
-	BuiltinMetricIDAPICacheBytesFree          = -100
-	BuiltinMetricIDAPICacheBytesTotal         = -101
-	BuiltinMetricIDAPICacheAgeEvict           = -102
-	BuiltinMetricIDAPICacheAgeTotal           = -103
-	BuiltinMetricIDAPIBufferBytesAlloc        = -104
-	BuiltinMetricIDAPIBufferBytesFree         = -105
-	BuiltinMetricIDAPIBufferBytesTotal        = -106
-	BuiltinMetricIDAutoCreateMetric           = -107
-	BuiltinMetricIDRestartTimings             = -108
-	BuiltinMetricIDGCDuration                 = -109
-	BuiltinMetricIDAggHistoricHostsWaiting    = -110
-	BuiltinMetricIDAggSamplingEngineTime      = -111
-	BuiltinMetricIDAggSamplingEngineKeys      = -112
+	// BuiltinMetricIDAggAgentSharding           = -98  // deprecated
+	BuiltinMetricIDAPICacheBytesAlloc      = -99
+	BuiltinMetricIDAPICacheBytesFree       = -100
+	BuiltinMetricIDAPICacheBytesTotal      = -101
+	BuiltinMetricIDAPICacheAgeEvict        = -102
+	BuiltinMetricIDAPICacheAgeTotal        = -103
+	BuiltinMetricIDAPIBufferBytesAlloc     = -104
+	BuiltinMetricIDAPIBufferBytesFree      = -105
+	BuiltinMetricIDAPIBufferBytesTotal     = -106
+	BuiltinMetricIDAutoCreateMetric        = -107
+	BuiltinMetricIDRestartTimings          = -108
+	BuiltinMetricIDGCDuration              = -109
+	BuiltinMetricIDAggHistoricHostsWaiting = -110
+	BuiltinMetricIDAggSamplingEngineTime   = -111
+	BuiltinMetricIDAggSamplingEngineKeys   = -112
 
 	// [-1000..-2000] reserved by host system metrics
 	// [-10000..-12000] reserved by builtin dashboard
@@ -173,7 +173,6 @@ const (
 	BuiltinMetricNamePromQLEngineTime           = "__promql_engine_time"
 	BuiltinMetricNameAPICacheHit                = "__api_cache_hit_rate"
 	BuiltinMetricNameIDUIErrors                 = "__ui_errors"
-	BuiltinMetricNameAggAgentSharding           = "__agg_agent_sharding"
 	BuiltinMetricAPICacheBytesAlloc             = "__api_cache_bytes_alloc"
 	BuiltinMetricAPICacheBytesFree              = "__api_cache_bytes_free"
 	BuiltinMetricAPICacheBytesTotal             = "__api_cache_bytes_total"
@@ -467,28 +466,6 @@ Set by aggregator.`,
 				}),
 			}, {
 				Description: "-",
-			}},
-		},
-		BuiltinMetricIDAggAgentSharding: {
-			Name:        BuiltinMetricNameAggAgentSharding,
-			Kind:        MetricKindCounter,
-			Resolution:  60,
-			Description: `# of agents with specific sharding scheme. Set by aggregator.`,
-			MetricType:  MetricSecond,
-			Tags: []MetricMetaTag{{
-				Description: "-",
-			}, {
-				Description: "-",
-			}, {
-				Description: "-",
-			}, {
-				Description: "sharding_by",
-				ValueComments: convertToValueComments(map[int32]string{
-					TagValueIDSharingByMappedTags: "mapped_tags",
-					TagValueIDSharingByMetricId:   "metric_id",
-				}),
-			}, {
-				Description: "host",
 			}},
 		},
 		BuiltinMetricIDAggInsertSize: {
@@ -2653,7 +2630,6 @@ Value is delta between second value and time it was inserted.`,
 	BuiltinMetricMetaAggSamplingTime            *MetricMetaValue
 	BuiltinMetricMetaAgentDiskCacheSize         *MetricMetaValue
 	BuiltinMetricMetaAggContributors            *MetricMetaValue
-	BuiltinMetricMetaAggAgentSharding           *MetricMetaValue
 	BuiltinMetricMetaAPICacheBytesAlloc         *MetricMetaValue
 	BuiltinMetricMetaAPICacheBytesFree          *MetricMetaValue
 	BuiltinMetricMetaAPICacheBytesTotal         *MetricMetaValue
@@ -2882,7 +2858,6 @@ func init() {
 	BuiltinMetricMetaAggSamplingTime = BuiltinMetrics[BuiltinMetricIDAggSamplingTime]
 	BuiltinMetricMetaAgentDiskCacheSize = BuiltinMetrics[BuiltinMetricIDAgentDiskCacheSize]
 	BuiltinMetricMetaAggContributors = BuiltinMetrics[BuiltinMetricIDAggContributors]
-	BuiltinMetricMetaAggAgentSharding = BuiltinMetrics[BuiltinMetricIDAggAgentSharding]
 	BuiltinMetricMetaAPICacheBytesAlloc = BuiltinMetrics[BuiltinMetricIDAPICacheBytesAlloc]
 	BuiltinMetricMetaAPICacheBytesFree = BuiltinMetrics[BuiltinMetricIDAPICacheBytesFree]
 	BuiltinMetricMetaAPICacheBytesTotal = BuiltinMetrics[BuiltinMetricIDAPICacheBytesTotal]

--- a/internal/format/builtin.go
+++ b/internal/format/builtin.go
@@ -692,10 +692,10 @@ This metric uses sampling budgets of metric it refers to, so flooding by errors 
 				Description: "tag_id",
 			}},
 			PreKeyTagID: "1",
-			Sharding: MetricSharding{
+			Sharding: []MetricSharding{{
 				Strategy: ShardByTag,
 				TagId:    opt.OUint32(1),
-			},
+			}},
 		},
 		BuiltinMetricIDAggInsertTime: {
 			Name:        "__agg_insert_time",
@@ -1136,10 +1136,10 @@ Set by aggregator.`,
 				IsMetric:    true,
 			}},
 			PreKeyTagID: "2",
-			Sharding: MetricSharding{
+			Sharding: []MetricSharding{{
 				Strategy: ShardByTag,
 				TagId:    opt.OUint32(2),
-			},
+			}},
 		},
 		BuiltinMetricIDAutoConfig: {
 			Name: "__autoconfig",
@@ -2790,11 +2790,11 @@ func init() {
 		}
 
 		// init sharding strategy if it's not explicitly defined
-		if m.Sharding.Strategy == "" {
-			m.Sharding = MetricSharding{
+		if len(m.Sharding) == 0 {
+			m.Sharding = []MetricSharding{{
 				Strategy: ShardByFixedShard,
 				Shard:    opt.OUint32(0),
-			}
+			}}
 		}
 		_ = m.RestoreCachedInfo()
 	}

--- a/internal/format/builtin.go
+++ b/internal/format/builtin.go
@@ -2567,6 +2567,107 @@ Value is delta between second value and time it was inserted.`,
 		" 1": "pool", // "sync.Pool", allocated buffer is subject for reuse (good)
 		" 2": "heap", // large buffer won't be reused (bad, should not happen)
 	}
+
+	// metic metas for builtin metrics are accessible directly without search in map
+	// they are initialized from BuiltinMetrics map in init() function
+	BuiltinMetricMetaAgentSamplingFactor        *MetricMetaValue
+	BuiltinMetricMetaAggBucketReceiveDelaySec   *MetricMetaValue
+	BuiltinMetricMetaAggInsertSize              *MetricMetaValue
+	BuiltinMetricMetaTLByteSizePerInflightType  *MetricMetaValue
+	BuiltinMetricMetaAggKeepAlive               *MetricMetaValue
+	BuiltinMetricMetaAggSizeCompressed          *MetricMetaValue
+	BuiltinMetricMetaAggSizeUncompressed        *MetricMetaValue
+	BuiltinMetricMetaAggAdditionsToEstimator    *MetricMetaValue
+	BuiltinMetricMetaAggHourCardinality         *MetricMetaValue
+	BuiltinMetricMetaAggSamplingFactor          *MetricMetaValue
+	BuiltinMetricMetaIngestionStatus            *MetricMetaValue
+	BuiltinMetricMetaAggInsertTime              *MetricMetaValue
+	BuiltinMetricMetaAggHistoricBucketsWaiting  *MetricMetaValue
+	BuiltinMetricMetaAggBucketAggregateTimeSec  *MetricMetaValue
+	BuiltinMetricMetaAggActiveSenders           *MetricMetaValue
+	BuiltinMetricMetaAggOutdatedAgents          *MetricMetaValue
+	BuiltinMetricMetaAgentDiskCacheErrors       *MetricMetaValue
+	BuiltinMetricMetaTimingErrors               *MetricMetaValue
+	BuiltinMetricMetaAgentReceivedBatchSize     *MetricMetaValue
+	BuiltinMetricMetaAggMapping                 *MetricMetaValue
+	BuiltinMetricMetaAggInsertTimeReal          *MetricMetaValue
+	BuiltinMetricMetaAgentHistoricQueueSize     *MetricMetaValue
+	BuiltinMetricMetaAggHistoricSecondsWaiting  *MetricMetaValue
+	BuiltinMetricMetaAggInsertSizeReal          *MetricMetaValue
+	BuiltinMetricMetaAgentMapping               *MetricMetaValue
+	BuiltinMetricMetaAgentReceivedPacketSize    *MetricMetaValue
+	BuiltinMetricMetaAggMappingCreated          *MetricMetaValue
+	BuiltinMetricMetaVersions                   *MetricMetaValue
+	BuiltinMetricMetaBadges                     *MetricMetaValue
+	BuiltinMetricMetaAutoConfig                 *MetricMetaValue
+	BuiltinMetricMetaJournalVersions            *MetricMetaValue
+	BuiltinMetricMetaPromScrapeTime             *MetricMetaValue
+	BuiltinMetricMetaAgentHeartbeatVersion      *MetricMetaValue
+	BuiltinMetricMetaAgentHeartbeatArgs         *MetricMetaValue
+	BuiltinMetricMetaUsageMemory                *MetricMetaValue
+	BuiltinMetricMetaUsageCPU                   *MetricMetaValue
+	BuiltinMetricMetaGeneratorConstCounter      *MetricMetaValue
+	BuiltinMetricMetaGeneratorSinCounter        *MetricMetaValue
+	BuiltinMetricMetaHeartbeatVersion           *MetricMetaValue
+	BuiltinMetricMetaHeartbeatArgs              *MetricMetaValue
+	BuiltinMetricMetaAPIBRS                     *MetricMetaValue
+	BuiltinMetricMetaBudgetHost                 *MetricMetaValue
+	BuiltinMetricMetaBudgetAggregatorHost       *MetricMetaValue
+	BuiltinMetricMetaAPIActiveQueries           *MetricMetaValue
+	BuiltinMetricMetaRPCRequests                *MetricMetaValue
+	BuiltinMetricMetaBudgetUnknownMetric        *MetricMetaValue
+	BuiltinMetricMetaContributorsLog            *MetricMetaValue
+	BuiltinMetricMetaContributorsLogRev         *MetricMetaValue
+	BuiltinMetricMetaGeneratorGapsCounter       *MetricMetaValue
+	BuiltinMetricMetaGroupSizeBeforeSampling    *MetricMetaValue
+	BuiltinMetricMetaGroupSizeAfterSampling     *MetricMetaValue
+	BuiltinMetricMetaAPISelectBytes             *MetricMetaValue
+	BuiltinMetricMetaAPISelectRows              *MetricMetaValue
+	BuiltinMetricMetaAPISelectDuration          *MetricMetaValue
+	BuiltinMetricMetaAgentHistoricQueueSizeSum  *MetricMetaValue
+	BuiltinMetricMetaAPISourceSelectRows        *MetricMetaValue
+	BuiltinMetricMetaSystemMetricScrapeDuration *MetricMetaValue
+	BuiltinMetricMetaMetaServiceTime            *MetricMetaValue
+	BuiltinMetricMetaMetaClientWaits            *MetricMetaValue
+	BuiltinMetricMetaAgentUDPReceiveBufferSize  *MetricMetaValue
+	BuiltinMetricMetaAPIMetricUsage             *MetricMetaValue
+	BuiltinMetricMetaAPIServiceTime             *MetricMetaValue
+	BuiltinMetricMetaAPIResponseTime            *MetricMetaValue
+	BuiltinMetricMetaSrcTestConnection          *MetricMetaValue
+	BuiltinMetricMetaAgentAggregatorTimeDiff    *MetricMetaValue
+	BuiltinMetricMetaSrcSamplingMetricCount     *MetricMetaValue
+	BuiltinMetricMetaAggSamplingMetricCount     *MetricMetaValue
+	BuiltinMetricMetaSrcSamplingSizeBytes       *MetricMetaValue
+	BuiltinMetricMetaAggSamplingSizeBytes       *MetricMetaValue
+	BuiltinMetricMetaUIErrors                   *MetricMetaValue
+	BuiltinMetricMetaStatsHouseErrors           *MetricMetaValue
+	BuiltinMetricMetaSrcSamplingBudget          *MetricMetaValue
+	BuiltinMetricMetaAggSamplingBudget          *MetricMetaValue
+	BuiltinMetricMetaSrcSamplingGroupBudget     *MetricMetaValue
+	BuiltinMetricMetaAggSamplingGroupBudget     *MetricMetaValue
+	BuiltinMetricMetaPromQLEngineTime           *MetricMetaValue
+	BuiltinMetricMetaAPICacheHit                *MetricMetaValue
+	BuiltinMetricMetaAggScrapeTargetDispatch    *MetricMetaValue
+	BuiltinMetricMetaAggScrapeTargetDiscovery   *MetricMetaValue
+	BuiltinMetricMetaAggScrapeConfigHash        *MetricMetaValue
+	BuiltinMetricMetaAggSamplingTime            *MetricMetaValue
+	BuiltinMetricMetaAgentDiskCacheSize         *MetricMetaValue
+	BuiltinMetricMetaAggContributors            *MetricMetaValue
+	BuiltinMetricMetaAggAgentSharding           *MetricMetaValue
+	BuiltinMetricMetaAPICacheBytesAlloc         *MetricMetaValue
+	BuiltinMetricMetaAPICacheBytesFree          *MetricMetaValue
+	BuiltinMetricMetaAPICacheBytesTotal         *MetricMetaValue
+	BuiltinMetricMetaAPICacheAgeEvict           *MetricMetaValue
+	BuiltinMetricMetaAPICacheAgeTotal           *MetricMetaValue
+	BuiltinMetricMetaAPIBufferBytesAlloc        *MetricMetaValue
+	BuiltinMetricMetaAPIBufferBytesFree         *MetricMetaValue
+	BuiltinMetricMetaAPIBufferBytesTotal        *MetricMetaValue
+	BuiltinMetricMetaAutoCreateMetric           *MetricMetaValue
+	BuiltinMetricMetaRestartTimings             *MetricMetaValue
+	BuiltinMetricMetaGCDuration                 *MetricMetaValue
+	BuiltinMetricMetaAggHistoricHostsWaiting    *MetricMetaValue
+	BuiltinMetricMetaAggSamplingEngineTime      *MetricMetaValue
+	BuiltinMetricMetaAggSamplingEngineKeys      *MetricMetaValue
 )
 
 func TagIDTagToTagID(tagIDTag int32) string {
@@ -2697,4 +2798,103 @@ func init() {
 		}
 		_ = m.RestoreCachedInfo()
 	}
+
+	BuiltinMetricMetaAgentSamplingFactor = BuiltinMetrics[BuiltinMetricIDAgentSamplingFactor]
+	BuiltinMetricMetaAggBucketReceiveDelaySec = BuiltinMetrics[BuiltinMetricIDAggBucketReceiveDelaySec]
+	BuiltinMetricMetaAggInsertSize = BuiltinMetrics[BuiltinMetricIDAggInsertSize]
+	BuiltinMetricMetaTLByteSizePerInflightType = BuiltinMetrics[BuiltinMetricIDTLByteSizePerInflightType]
+	BuiltinMetricMetaAggKeepAlive = BuiltinMetrics[BuiltinMetricIDAggKeepAlive]
+	BuiltinMetricMetaAggSizeCompressed = BuiltinMetrics[BuiltinMetricIDAggSizeCompressed]
+	BuiltinMetricMetaAggSizeUncompressed = BuiltinMetrics[BuiltinMetricIDAggSizeUncompressed]
+	BuiltinMetricMetaAggAdditionsToEstimator = BuiltinMetrics[BuiltinMetricIDAggAdditionsToEstimator]
+	BuiltinMetricMetaAggHourCardinality = BuiltinMetrics[BuiltinMetricIDAggHourCardinality]
+	BuiltinMetricMetaAggSamplingFactor = BuiltinMetrics[BuiltinMetricIDAggSamplingFactor]
+	BuiltinMetricMetaIngestionStatus = BuiltinMetrics[BuiltinMetricIDIngestionStatus]
+	BuiltinMetricMetaAggInsertTime = BuiltinMetrics[BuiltinMetricIDAggInsertTime]
+	BuiltinMetricMetaAggHistoricBucketsWaiting = BuiltinMetrics[BuiltinMetricIDAggHistoricBucketsWaiting]
+	BuiltinMetricMetaAggBucketAggregateTimeSec = BuiltinMetrics[BuiltinMetricIDAggBucketAggregateTimeSec]
+	BuiltinMetricMetaAggActiveSenders = BuiltinMetrics[BuiltinMetricIDAggActiveSenders]
+	BuiltinMetricMetaAggOutdatedAgents = BuiltinMetrics[BuiltinMetricIDAggOutdatedAgents]
+	BuiltinMetricMetaAgentDiskCacheErrors = BuiltinMetrics[BuiltinMetricIDAgentDiskCacheErrors]
+	BuiltinMetricMetaTimingErrors = BuiltinMetrics[BuiltinMetricIDTimingErrors]
+	BuiltinMetricMetaAgentReceivedBatchSize = BuiltinMetrics[BuiltinMetricIDAgentReceivedBatchSize]
+	BuiltinMetricMetaAggMapping = BuiltinMetrics[BuiltinMetricIDAggMapping]
+	BuiltinMetricMetaAggInsertTimeReal = BuiltinMetrics[BuiltinMetricIDAggInsertTimeReal]
+	BuiltinMetricMetaAgentHistoricQueueSize = BuiltinMetrics[BuiltinMetricIDAgentHistoricQueueSize]
+	BuiltinMetricMetaAggHistoricSecondsWaiting = BuiltinMetrics[BuiltinMetricIDAggHistoricSecondsWaiting]
+	BuiltinMetricMetaAggInsertSizeReal = BuiltinMetrics[BuiltinMetricIDAggInsertSizeReal]
+	BuiltinMetricMetaAgentMapping = BuiltinMetrics[BuiltinMetricIDAgentMapping]
+	BuiltinMetricMetaAgentReceivedPacketSize = BuiltinMetrics[BuiltinMetricIDAgentReceivedPacketSize]
+	BuiltinMetricMetaAggMappingCreated = BuiltinMetrics[BuiltinMetricIDAggMappingCreated]
+	BuiltinMetricMetaVersions = BuiltinMetrics[BuiltinMetricIDVersions]
+	BuiltinMetricMetaBadges = BuiltinMetrics[BuiltinMetricIDBadges]
+	BuiltinMetricMetaAutoConfig = BuiltinMetrics[BuiltinMetricIDAutoConfig]
+	BuiltinMetricMetaJournalVersions = BuiltinMetrics[BuiltinMetricIDJournalVersions]
+	BuiltinMetricMetaPromScrapeTime = BuiltinMetrics[BuiltinMetricIDPromScrapeTime]
+	BuiltinMetricMetaAgentHeartbeatVersion = BuiltinMetrics[BuiltinMetricIDAgentHeartbeatVersion]
+	BuiltinMetricMetaAgentHeartbeatArgs = BuiltinMetrics[BuiltinMetricIDAgentHeartbeatArgs]
+	BuiltinMetricMetaUsageMemory = BuiltinMetrics[BuiltinMetricIDUsageMemory]
+	BuiltinMetricMetaUsageCPU = BuiltinMetrics[BuiltinMetricIDUsageCPU]
+	BuiltinMetricMetaGeneratorConstCounter = BuiltinMetrics[BuiltinMetricIDGeneratorConstCounter]
+	BuiltinMetricMetaGeneratorSinCounter = BuiltinMetrics[BuiltinMetricIDGeneratorSinCounter]
+	BuiltinMetricMetaHeartbeatVersion = BuiltinMetrics[BuiltinMetricIDHeartbeatVersion]
+	BuiltinMetricMetaHeartbeatArgs = BuiltinMetrics[BuiltinMetricIDHeartbeatArgs]
+	BuiltinMetricMetaAPIBRS = BuiltinMetrics[BuiltinMetricIDAPIBRS]
+	BuiltinMetricMetaBudgetHost = BuiltinMetrics[BuiltinMetricIDBudgetHost]
+	BuiltinMetricMetaBudgetAggregatorHost = BuiltinMetrics[BuiltinMetricIDBudgetAggregatorHost]
+	BuiltinMetricMetaAPIActiveQueries = BuiltinMetrics[BuiltinMetricIDAPIActiveQueries]
+	BuiltinMetricMetaRPCRequests = BuiltinMetrics[BuiltinMetricIDRPCRequests]
+	BuiltinMetricMetaBudgetUnknownMetric = BuiltinMetrics[BuiltinMetricIDBudgetUnknownMetric]
+	BuiltinMetricMetaContributorsLog = BuiltinMetrics[BuiltinMetricIDContributorsLog]
+	BuiltinMetricMetaContributorsLogRev = BuiltinMetrics[BuiltinMetricIDContributorsLogRev]
+	BuiltinMetricMetaGeneratorGapsCounter = BuiltinMetrics[BuiltinMetricIDGeneratorGapsCounter]
+	BuiltinMetricMetaGroupSizeBeforeSampling = BuiltinMetrics[BuiltinMetricIDGroupSizeBeforeSampling]
+	BuiltinMetricMetaGroupSizeAfterSampling = BuiltinMetrics[BuiltinMetricIDGroupSizeAfterSampling]
+	BuiltinMetricMetaAPISelectBytes = BuiltinMetrics[BuiltinMetricIDAPISelectBytes]
+	BuiltinMetricMetaAPISelectRows = BuiltinMetrics[BuiltinMetricIDAPISelectRows]
+	BuiltinMetricMetaAPISelectDuration = BuiltinMetrics[BuiltinMetricIDAPISelectDuration]
+	BuiltinMetricMetaAgentHistoricQueueSizeSum = BuiltinMetrics[BuiltinMetricIDAgentHistoricQueueSizeSum]
+	BuiltinMetricMetaAPISourceSelectRows = BuiltinMetrics[BuiltinMetricIDAPISourceSelectRows]
+	BuiltinMetricMetaSystemMetricScrapeDuration = BuiltinMetrics[BuiltinMetricIDSystemMetricScrapeDuration]
+	BuiltinMetricMetaMetaServiceTime = BuiltinMetrics[BuiltinMetricIDMetaServiceTime]
+	BuiltinMetricMetaMetaClientWaits = BuiltinMetrics[BuiltinMetricIDMetaClientWaits]
+	BuiltinMetricMetaAgentUDPReceiveBufferSize = BuiltinMetrics[BuiltinMetricIDAgentUDPReceiveBufferSize]
+	BuiltinMetricMetaAPIMetricUsage = BuiltinMetrics[BuiltinMetricIDAPIMetricUsage]
+	BuiltinMetricMetaAPIServiceTime = BuiltinMetrics[BuiltinMetricIDAPIServiceTime]
+	BuiltinMetricMetaAPIResponseTime = BuiltinMetrics[BuiltinMetricIDAPIResponseTime]
+	BuiltinMetricMetaSrcTestConnection = BuiltinMetrics[BuiltinMetricIDSrcTestConnection]
+	BuiltinMetricMetaAgentAggregatorTimeDiff = BuiltinMetrics[BuiltinMetricIDAgentAggregatorTimeDiff]
+	BuiltinMetricMetaSrcSamplingMetricCount = BuiltinMetrics[BuiltinMetricIDSrcSamplingMetricCount]
+	BuiltinMetricMetaAggSamplingMetricCount = BuiltinMetrics[BuiltinMetricIDAggSamplingMetricCount]
+	BuiltinMetricMetaSrcSamplingSizeBytes = BuiltinMetrics[BuiltinMetricIDSrcSamplingSizeBytes]
+	BuiltinMetricMetaAggSamplingSizeBytes = BuiltinMetrics[BuiltinMetricIDAggSamplingSizeBytes]
+	BuiltinMetricMetaUIErrors = BuiltinMetrics[BuiltinMetricIDUIErrors]
+	BuiltinMetricMetaStatsHouseErrors = BuiltinMetrics[BuiltinMetricIDStatsHouseErrors]
+	BuiltinMetricMetaSrcSamplingBudget = BuiltinMetrics[BuiltinMetricIDSrcSamplingBudget]
+	BuiltinMetricMetaAggSamplingBudget = BuiltinMetrics[BuiltinMetricIDAggSamplingBudget]
+	BuiltinMetricMetaSrcSamplingGroupBudget = BuiltinMetrics[BuiltinMetricIDSrcSamplingGroupBudget]
+	BuiltinMetricMetaAggSamplingGroupBudget = BuiltinMetrics[BuiltinMetricIDAggSamplingGroupBudget]
+	BuiltinMetricMetaPromQLEngineTime = BuiltinMetrics[BuiltinMetricIDPromQLEngineTime]
+	BuiltinMetricMetaAPICacheHit = BuiltinMetrics[BuiltinMetricIDAPICacheHit]
+	BuiltinMetricMetaAggScrapeTargetDispatch = BuiltinMetrics[BuiltinMetricIDAggScrapeTargetDispatch]
+	BuiltinMetricMetaAggScrapeTargetDiscovery = BuiltinMetrics[BuiltinMetricIDAggScrapeTargetDiscovery]
+	BuiltinMetricMetaAggScrapeConfigHash = BuiltinMetrics[BuiltinMetricIDAggScrapeConfigHash]
+	BuiltinMetricMetaAggSamplingTime = BuiltinMetrics[BuiltinMetricIDAggSamplingTime]
+	BuiltinMetricMetaAgentDiskCacheSize = BuiltinMetrics[BuiltinMetricIDAgentDiskCacheSize]
+	BuiltinMetricMetaAggContributors = BuiltinMetrics[BuiltinMetricIDAggContributors]
+	BuiltinMetricMetaAggAgentSharding = BuiltinMetrics[BuiltinMetricIDAggAgentSharding]
+	BuiltinMetricMetaAPICacheBytesAlloc = BuiltinMetrics[BuiltinMetricIDAPICacheBytesAlloc]
+	BuiltinMetricMetaAPICacheBytesFree = BuiltinMetrics[BuiltinMetricIDAPICacheBytesFree]
+	BuiltinMetricMetaAPICacheBytesTotal = BuiltinMetrics[BuiltinMetricIDAPICacheBytesTotal]
+	BuiltinMetricMetaAPICacheAgeEvict = BuiltinMetrics[BuiltinMetricIDAPICacheAgeEvict]
+	BuiltinMetricMetaAPICacheAgeTotal = BuiltinMetrics[BuiltinMetricIDAPICacheAgeTotal]
+	BuiltinMetricMetaAPIBufferBytesAlloc = BuiltinMetrics[BuiltinMetricIDAPIBufferBytesAlloc]
+	BuiltinMetricMetaAPIBufferBytesFree = BuiltinMetrics[BuiltinMetricIDAPIBufferBytesFree]
+	BuiltinMetricMetaAPIBufferBytesTotal = BuiltinMetrics[BuiltinMetricIDAPIBufferBytesTotal]
+	BuiltinMetricMetaAutoCreateMetric = BuiltinMetrics[BuiltinMetricIDAutoCreateMetric]
+	BuiltinMetricMetaRestartTimings = BuiltinMetrics[BuiltinMetricIDRestartTimings]
+	BuiltinMetricMetaGCDuration = BuiltinMetrics[BuiltinMetricIDGCDuration]
+	BuiltinMetricMetaAggHistoricHostsWaiting = BuiltinMetrics[BuiltinMetricIDAggHistoricHostsWaiting]
+	BuiltinMetricMetaAggSamplingEngineTime = BuiltinMetrics[BuiltinMetricIDAggSamplingEngineTime]
+	BuiltinMetricMetaAggSamplingEngineKeys = BuiltinMetrics[BuiltinMetricIDAggSamplingEngineKeys]
 }

--- a/internal/format/builtin.go
+++ b/internal/format/builtin.go
@@ -1114,8 +1114,7 @@ Set by aggregator.`,
 			}},
 			PreKeyTagID: "2",
 			Sharding: []MetricSharding{{
-				Strategy: ShardByTag,
-				TagId:    opt.OUint32(2),
+				Strategy: ShardAggInternal,
 			}},
 		},
 		BuiltinMetricIDAutoConfig: {
@@ -2768,7 +2767,7 @@ func init() {
 		// init sharding strategy if it's not explicitly defined
 		if len(m.Sharding) == 0 {
 			m.Sharding = []MetricSharding{{
-				Strategy: ShardByFixedShard,
+				Strategy: ShardFixed,
 				Shard:    opt.OUint32(0),
 			}}
 		}

--- a/internal/format/builtin.go
+++ b/internal/format/builtin.go
@@ -10,6 +10,8 @@ import (
 	"log"
 	"math"
 	"strconv"
+
+	"github.com/mailru/easyjson/opt"
 )
 
 const (
@@ -688,6 +690,10 @@ This metric uses sampling budgets of metric it refers to, so flooding by errors 
 				Description: "tag_id",
 			}},
 			PreKeyTagID: "1",
+			Sharding: MetricSharding{
+				Strategy: ShardByTag,
+				TagId:    opt.OUint32(1),
+			},
 		},
 		BuiltinMetricIDAggInsertTime: {
 			Name:        "__agg_insert_time",
@@ -1128,6 +1134,10 @@ Set by aggregator.`,
 				IsMetric:    true,
 			}},
 			PreKeyTagID: "2",
+			Sharding: MetricSharding{
+				Strategy: ShardByTag,
+				TagId:    opt.OUint32(2),
+			},
 		},
 		BuiltinMetricIDAutoConfig: {
 			Name: "__autoconfig",
@@ -2674,6 +2684,14 @@ func init() {
 				m.Tags[i].Raw = true
 			}
 			// Also some tags are simply marked with Raw:true above
+		}
+
+		// init sharding strategy if it's not explicitly defined
+		if m.Sharding.Strategy == "" {
+			m.Sharding = MetricSharding{
+				Strategy: ShardByFixedShard,
+				Shard:    opt.OUint32(0),
+			}
 		}
 		_ = m.RestoreCachedInfo()
 	}

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -21,6 +21,8 @@ import (
 	"go.uber.org/multierr"
 	"go4.org/mem"
 
+	"github.com/mailru/easyjson/opt"
+
 	"github.com/vkcom/statshouse-go"
 )
 
@@ -205,6 +207,19 @@ type MetricsGroup struct {
 	Namespace       *NamespaceMeta `json:"-"`
 }
 
+// possible sharding strategies
+const (
+	MappedTags = "mapped_tags"
+	FixedShard = "fixed_shard"
+	Tag        = "tag"
+)
+
+type MetricSharding struct {
+	Strategy string     `json:"strategy"`         // possible values: mapped_tags, fixed_shard, tag
+	Shard    opt.Uint32 `json:"shard,omitempty"`  // only for "fixed_shard" strategy
+	TagId    opt.Uint32 `json:"tag_id,omitempty"` // only for "tag" strategy
+}
+
 // This struct is immutable, it is accessed by mapping code without any locking
 type MetricMetaValue struct {
 	MetricID    int32  `json:"metric_id"`
@@ -230,6 +245,7 @@ type MetricMetaValue struct {
 	PreKeyOnly           bool                     `json:"pre_key_only,omitempty"`
 	MetricType           string                   `json:"metric_type"`
 	FairKeyTagIDs        []string                 `json:"fair_key_tag_ids,omitempty"`
+	Sharding             MetricSharding           `json:"sharding,omitempty"`
 
 	RawTagMask          uint32                   `json:"-"` // Should be restored from Tags after reading
 	Name2Tag            map[string]MetricMetaTag `json:"-"` // Should be restored from Tags after reading
@@ -497,6 +513,13 @@ func (m *MetricMetaValue) RestoreCachedInfo() error {
 			}
 		}
 	}
+	// default strategy if it's not configured
+	if m.Sharding.Strategy == "" {
+		m.Sharding.Strategy = MappedTags
+	}
+	if validationErr := ValidSharding(m.Sharding); validationErr != nil {
+		err = multierr.Append(err, validationErr)
+	}
 	return err
 }
 
@@ -672,6 +695,33 @@ func ValidRawKind(s string) bool {
 		return true
 	}
 	return false
+}
+
+func ValidSharding(sharding MetricSharding) error {
+	switch sharding.Strategy {
+	case MappedTags:
+		if sharding.Shard.IsDefined() || sharding.TagId.IsDefined() {
+			return fmt.Errorf("%s strategy is incompative with shard or tag_id", MappedTags)
+		}
+		return nil
+	case FixedShard:
+		if !sharding.Shard.IsDefined() || sharding.TagId.IsDefined() {
+			return fmt.Errorf("%s strategy requires shard to be set", FixedShard)
+		}
+		if sharding.TagId.IsDefined() {
+			return fmt.Errorf("%s strategy is incompative with tag_id", FixedShard)
+		}
+		return nil
+	case Tag:
+		if !sharding.TagId.IsDefined() {
+			return fmt.Errorf("%s strategy requires tag_id to be set", Tag)
+		}
+		if sharding.Shard.IsDefined() {
+			return fmt.Errorf("%s strategy is incompative with shard", Tag)
+		}
+		return nil
+	}
+	return fmt.Errorf("unknown strategy %s", sharding.Strategy)
 }
 
 func TagIndex(tagID string) int { // inverse of 'TagID'

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -214,6 +214,9 @@ const (
 	ShardByTag              = "tag"
 	// some builtin metrics are produced direclty by aggregator, so they are written to shard in which they are produced
 	ShardAggInternal = "agg_internal"
+	// shard = metric_id % num_shards
+	// it's only used for hardware metrics, overall not recommended because shard depends on total number of shards
+	ShardByMetricId = "metric_id"
 )
 
 type MetricSharding struct {
@@ -705,7 +708,7 @@ func ValidRawKind(s string) bool {
 
 func ValidSharding(sharding MetricSharding) error {
 	switch sharding.Strategy {
-	case ShardBy16MappedTagsHash, ShardAggInternal:
+	case ShardBy16MappedTagsHash, ShardAggInternal, ShardByMetricId:
 		if sharding.Shard.IsDefined() || sharding.TagId.IsDefined() {
 			return fmt.Errorf("%s strategy is incompative with shard or tag_id", sharding.Strategy)
 		}

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -209,9 +209,9 @@ type MetricsGroup struct {
 
 // possible sharding strategies
 const (
-	MappedTags = "mapped_tags"
-	FixedShard = "fixed_shard"
-	Tag        = "tag"
+	ShardByMappedTags = "mapped_tags"
+	ShardByFixedShard = "fixed_shard"
+	ShardByTag        = "tag"
 )
 
 type MetricSharding struct {
@@ -515,7 +515,7 @@ func (m *MetricMetaValue) RestoreCachedInfo() error {
 	}
 	// default strategy if it's not configured
 	if m.Sharding.Strategy == "" {
-		m.Sharding.Strategy = MappedTags
+		m.Sharding.Strategy = ShardByMappedTags
 	}
 	if validationErr := ValidSharding(m.Sharding); validationErr != nil {
 		err = multierr.Append(err, validationErr)
@@ -699,25 +699,25 @@ func ValidRawKind(s string) bool {
 
 func ValidSharding(sharding MetricSharding) error {
 	switch sharding.Strategy {
-	case MappedTags:
+	case ShardByMappedTags:
 		if sharding.Shard.IsDefined() || sharding.TagId.IsDefined() {
-			return fmt.Errorf("%s strategy is incompative with shard or tag_id", MappedTags)
+			return fmt.Errorf("%s strategy is incompative with shard or tag_id", ShardByMappedTags)
 		}
 		return nil
-	case FixedShard:
+	case ShardByFixedShard:
 		if !sharding.Shard.IsDefined() || sharding.TagId.IsDefined() {
-			return fmt.Errorf("%s strategy requires shard to be set", FixedShard)
+			return fmt.Errorf("%s strategy requires shard to be set", ShardByFixedShard)
 		}
 		if sharding.TagId.IsDefined() {
-			return fmt.Errorf("%s strategy is incompative with tag_id", FixedShard)
+			return fmt.Errorf("%s strategy is incompative with tag_id", ShardByFixedShard)
 		}
 		return nil
-	case Tag:
+	case ShardByTag:
 		if !sharding.TagId.IsDefined() {
-			return fmt.Errorf("%s strategy requires tag_id to be set", Tag)
+			return fmt.Errorf("%s strategy requires tag_id to be set", ShardByTag)
 		}
 		if sharding.Shard.IsDefined() {
-			return fmt.Errorf("%s strategy is incompative with shard", Tag)
+			return fmt.Errorf("%s strategy is incompative with shard", ShardByTag)
 		}
 		return nil
 	}

--- a/internal/receiver/receiver.go
+++ b/internal/receiver/receiver.go
@@ -9,12 +9,13 @@ package receiver
 import (
 	"strings"
 
+	"go.uber.org/atomic"
+
 	"github.com/vkcom/statshouse/internal/agent"
 	"github.com/vkcom/statshouse/internal/data_model"
 	"github.com/vkcom/statshouse/internal/data_model/gen2/tlstatshouse"
 	"github.com/vkcom/statshouse/internal/format"
 	"github.com/vkcom/statshouse/internal/mapping"
-	"go.uber.org/atomic"
 )
 
 const (
@@ -145,7 +146,7 @@ func createBatchSizeValue(ag *agent.Agent, formatTagValueID int32, statusTagValu
 		return ag.CreateBuiltInItemValue(data_model.Key{
 			Metric: format.BuiltinMetricIDAgentReceivedBatchSize,
 			Keys:   [format.MaxTags]int32{0 /* env */, formatTagValueID, statusTagValueID, protocolTagValueID},
-		})
+		}, format.BuiltinMetricMetaAgentReceivedBatchSize)
 	}
 	return nil
 }
@@ -155,7 +156,7 @@ func createPacketSizeValue(bm *agent.Agent, formatTagValueID int32, statusTagVal
 		return bm.CreateBuiltInItemValue(data_model.Key{
 			Metric: format.BuiltinMetricIDAgentReceivedPacketSize,
 			Keys:   [format.MaxTags]int32{0 /* env */, formatTagValueID, statusTagValueID, protocolTagValueID},
-		})
+		}, format.BuiltinMetricMetaAgentReceivedPacketSize)
 	}
 	return nil
 }

--- a/internal/sharding/sharding.go
+++ b/internal/sharding/sharding.go
@@ -9,7 +9,7 @@ import (
 
 func Shard(key data_model.Key, sharding format.MetricSharding, numShards int) (uint32, error) {
 	switch sharding.Strategy {
-	case format.FixedShard:
+	case format.ShardByFixedShard:
 		if !sharding.Shard.IsDefined() {
 			return 0, fmt.Errorf("invalid sharding config: shard is not defined")
 		}
@@ -17,9 +17,9 @@ func Shard(key data_model.Key, sharding format.MetricSharding, numShards int) (u
 			return 0, fmt.Errorf("invalid sharding config: shard >= numShards")
 		}
 		return sharding.Shard.V, nil
-	case format.MappedTags:
+	case format.ShardByMappedTags:
 		return shardByMappedTags(key, numShards), nil
-	case format.Tag:
+	case format.ShardByTag:
 		if !sharding.TagId.IsDefined() {
 			return 0, fmt.Errorf("invalid sharding config: tag_id is not defined")
 		}

--- a/internal/sharding/sharding.go
+++ b/internal/sharding/sharding.go
@@ -13,12 +13,18 @@ func Shard(key data_model.Key, sharding format.MetricSharding, numShards int) (u
 		if !sharding.Shard.IsDefined() {
 			return 0, fmt.Errorf("invalid sharding config: shard is not defined")
 		}
+		if sharding.Shard.V >= uint32(numShards) {
+			return 0, fmt.Errorf("invalid sharding config: shard >= numShards")
+		}
 		return sharding.Shard.V, nil
 	case format.MappedTags:
 		return shardByMappedTags(key, numShards), nil
 	case format.Tag:
 		if !sharding.TagId.IsDefined() {
 			return 0, fmt.Errorf("invalid sharding config: tag_id is not defined")
+		}
+		if sharding.TagId.V >= format.MaxTags {
+			return 0, fmt.Errorf("invalid sharding config: tag_id >= MaxTags")
 		}
 		return shardByTag(key, sharding.TagId.V, numShards), nil
 	}

--- a/internal/sharding/sharding.go
+++ b/internal/sharding/sharding.go
@@ -1,0 +1,36 @@
+package sharding
+
+import (
+	"fmt"
+
+	"github.com/vkcom/statshouse/internal/data_model"
+	"github.com/vkcom/statshouse/internal/format"
+)
+
+func Shard(key data_model.Key, sharding format.MetricSharding, numShards int) (uint32, error) {
+	switch sharding.Strategy {
+	case format.FixedShard:
+		if !sharding.Shard.IsDefined() {
+			return 0, fmt.Errorf("invalid sharding config: shard is not defined")
+		}
+		return sharding.Shard.V, nil
+	case format.MappedTags:
+		return shardByMappedTags(key, numShards), nil
+	case format.Tag:
+		if !sharding.TagId.IsDefined() {
+			return 0, fmt.Errorf("invalid sharding config: tag_id is not defined")
+		}
+		return shardByTag(key, sharding.TagId.V, numShards), nil
+	}
+	return 0, fmt.Errorf("invalid sharding config: unknown strategy")
+}
+
+func shardByMappedTags(key data_model.Key, numShards int) uint32 {
+	hash := key.Hash()
+	mul := (hash >> 32) * uint64(numShards) >> 32 // trunc([0..0.9999999] * numShards) in fixed point 32.32
+	return uint32(mul)
+}
+
+func shardByTag(key data_model.Key, tagId uint32, numShards int) uint32 {
+	return uint32(key.Keys[tagId]) % uint32(numShards)
+}

--- a/internal/sharding/sharding.go
+++ b/internal/sharding/sharding.go
@@ -37,6 +37,8 @@ func Shard(key data_model.Key, meta *format.MetricMetaValue, numShards int, buil
 			return 0, "", fmt.Errorf("invalid sharding config: tag_id >= MaxTags")
 		}
 		return shardByTag(key, sh.TagId.V, numShards), sh.Strategy, nil
+	case format.ShardByMetricId:
+		return shardByMetricId(key, numShards), sh.Strategy, nil
 	}
 	return 0, "", fmt.Errorf("invalid sharding config: unknown strategy")
 }
@@ -49,6 +51,10 @@ func shardByMappedTags(key data_model.Key, numShards int) uint32 {
 
 func shardByTag(key data_model.Key, tagId uint32, numShards int) uint32 {
 	return uint32(key.Keys[tagId]) % uint32(numShards)
+}
+
+func shardByMetricId(key data_model.Key, numShards int) uint32 {
+	return uint32(key.Metric) % uint32(numShards)
 }
 
 func choseShardingStrategy(key data_model.Key, meta *format.MetricMetaValue) (sh format.MetricSharding) {

--- a/internal/sharding/sharding.go
+++ b/internal/sharding/sharding.go
@@ -25,7 +25,7 @@ func Shard(key data_model.Key, meta *format.MetricMetaValue, numShards int) (uin
 	}
 
 	switch sh.Strategy {
-	case format.ShardByFixedShard:
+	case format.ShardFixed:
 		if !sh.Shard.IsDefined() {
 			return 0, "", fmt.Errorf("invalid sharding config: shard is not defined")
 		}
@@ -33,7 +33,7 @@ func Shard(key data_model.Key, meta *format.MetricMetaValue, numShards int) (uin
 			return 0, "", fmt.Errorf("invalid sharding config: shard >= numShards")
 		}
 		return sh.Shard.V, sh.Strategy, nil
-	case format.ShardByMappedTags:
+	case format.ShardBy16MappedTagsHash:
 		return shardByMappedTags(key, numShards), sh.Strategy, nil
 	case format.ShardByTag:
 		if !sh.TagId.IsDefined() {

--- a/internal/sharding/sharding_test.go
+++ b/internal/sharding/sharding_test.go
@@ -26,23 +26,23 @@ func TestShard(t *testing.T) {
 		wantErr bool
 	}{
 		// be careful, if this tests are failing then we changed shardig schema
-		{"ok-by-tags-1", args{key: metric1, sharding: format.MetricSharding{Strategy: format.MappedTags}, numShards: 16}, 8, false},
-		{"ok-by-tags-2", args{key: metric2, sharding: format.MetricSharding{Strategy: format.MappedTags}, numShards: 16}, 15, false},
-		{"ok-by-tags-builtin", args{key: metricBuiltin, sharding: format.MetricSharding{Strategy: format.MappedTags}, numShards: 16}, 5, false},
+		{"ok-by-tags-1", args{key: metric1, sharding: format.MetricSharding{Strategy: format.ShardByMappedTags}, numShards: 16}, 8, false},
+		{"ok-by-tags-2", args{key: metric2, sharding: format.MetricSharding{Strategy: format.ShardByMappedTags}, numShards: 16}, 15, false},
+		{"ok-by-tags-builtin", args{key: metricBuiltin, sharding: format.MetricSharding{Strategy: format.ShardByMappedTags}, numShards: 16}, 5, false},
 
-		{"ok-fixed-1", args{key: metric1, sharding: format.MetricSharding{Strategy: format.FixedShard, Shard: opt.OUint32(3)}, numShards: 16}, 3, false},
-		{"ok-fixed-2", args{key: metric2, sharding: format.MetricSharding{Strategy: format.FixedShard, Shard: opt.OUint32(4)}, numShards: 16}, 4, false},
-		{"ok-fixed-builtin", args{key: metricBuiltin, sharding: format.MetricSharding{Strategy: format.FixedShard, Shard: opt.OUint32(0)}, numShards: 16}, 0, false},
+		{"ok-fixed-1", args{key: metric1, sharding: format.MetricSharding{Strategy: format.ShardByFixedShard, Shard: opt.OUint32(3)}, numShards: 16}, 3, false},
+		{"ok-fixed-2", args{key: metric2, sharding: format.MetricSharding{Strategy: format.ShardByFixedShard, Shard: opt.OUint32(4)}, numShards: 16}, 4, false},
+		{"ok-fixed-builtin", args{key: metricBuiltin, sharding: format.MetricSharding{Strategy: format.ShardByFixedShard, Shard: opt.OUint32(0)}, numShards: 16}, 0, false},
 
-		{"ok-by-tag-1", args{key: metric1, sharding: format.MetricSharding{Strategy: format.Tag, TagId: opt.OUint32(1)}, numShards: 16}, 2, false},
-		{"ok-by-tag-2", args{key: metric2, sharding: format.MetricSharding{Strategy: format.Tag, TagId: opt.OUint32(1)}, numShards: 16}, 6, false},
-		{"ok-by-tag-builtin", args{key: metricBuiltin, sharding: format.MetricSharding{Strategy: format.Tag, TagId: opt.OUint32(0)}, numShards: 16}, 0, false},
+		{"ok-by-tag-1", args{key: metric1, sharding: format.MetricSharding{Strategy: format.ShardByTag, TagId: opt.OUint32(1)}, numShards: 16}, 2, false},
+		{"ok-by-tag-2", args{key: metric2, sharding: format.MetricSharding{Strategy: format.ShardByTag, TagId: opt.OUint32(1)}, numShards: 16}, 6, false},
+		{"ok-by-tag-builtin", args{key: metricBuiltin, sharding: format.MetricSharding{Strategy: format.ShardByTag, TagId: opt.OUint32(0)}, numShards: 16}, 0, false},
 
 		// negative cases
-		{"fail-fixed-no-shard", args{key: metric1, sharding: format.MetricSharding{Strategy: format.FixedShard}, numShards: 16}, 0, true},
-		{"fail-fixed-bad-shard", args{key: metric1, sharding: format.MetricSharding{Strategy: format.FixedShard, Shard: opt.OUint32(1000)}, numShards: 16}, 0, true},
-		{"fail-by-tag-no-id", args{key: metric1, sharding: format.MetricSharding{Strategy: format.Tag}, numShards: 16}, 0, true},
-		{"fail-by-tag-bad-id", args{key: metric1, sharding: format.MetricSharding{Strategy: format.Tag, TagId: opt.OUint32(1000)}, numShards: 16}, 0, true},
+		{"fail-fixed-no-shard", args{key: metric1, sharding: format.MetricSharding{Strategy: format.ShardByFixedShard}, numShards: 16}, 0, true},
+		{"fail-fixed-bad-shard", args{key: metric1, sharding: format.MetricSharding{Strategy: format.ShardByFixedShard, Shard: opt.OUint32(1000)}, numShards: 16}, 0, true},
+		{"fail-by-tag-no-id", args{key: metric1, sharding: format.MetricSharding{Strategy: format.ShardByTag}, numShards: 16}, 0, true},
+		{"fail-by-tag-bad-id", args{key: metric1, sharding: format.MetricSharding{Strategy: format.ShardByTag, TagId: opt.OUint32(1000)}, numShards: 16}, 0, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/sharding/sharding_test.go
+++ b/internal/sharding/sharding_test.go
@@ -1,0 +1,59 @@
+package sharding
+
+import (
+	"testing"
+
+	"github.com/mailru/easyjson/opt"
+
+	"github.com/vkcom/statshouse/internal/data_model"
+	"github.com/vkcom/statshouse/internal/format"
+)
+
+func TestShard(t *testing.T) {
+	metric1 := data_model.Key{Timestamp: 1000, Metric: 1, Keys: [format.MaxTags]int32{1, 2, 3}}
+	metric2 := data_model.Key{Timestamp: 1000, Metric: 2, Keys: [format.MaxTags]int32{5, 6}}
+	metricBuiltin := data_model.Key{Timestamp: 1000, Metric: -1000}
+
+	type args struct {
+		key       data_model.Key
+		sharding  format.MetricSharding
+		numShards int
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    uint32
+		wantErr bool
+	}{
+		// be careful, if this tests are failing then we changed shardig schema
+		{"ok-by-tags-1", args{key: metric1, sharding: format.MetricSharding{Strategy: format.MappedTags}, numShards: 16}, 8, false},
+		{"ok-by-tags-2", args{key: metric2, sharding: format.MetricSharding{Strategy: format.MappedTags}, numShards: 16}, 15, false},
+		{"ok-by-tags-builtin", args{key: metricBuiltin, sharding: format.MetricSharding{Strategy: format.MappedTags}, numShards: 16}, 5, false},
+
+		{"ok-fixed-1", args{key: metric1, sharding: format.MetricSharding{Strategy: format.FixedShard, Shard: opt.OUint32(3)}, numShards: 16}, 3, false},
+		{"ok-fixed-2", args{key: metric2, sharding: format.MetricSharding{Strategy: format.FixedShard, Shard: opt.OUint32(4)}, numShards: 16}, 4, false},
+		{"ok-fixed-builtin", args{key: metricBuiltin, sharding: format.MetricSharding{Strategy: format.FixedShard, Shard: opt.OUint32(0)}, numShards: 16}, 0, false},
+
+		{"ok-by-tag-1", args{key: metric1, sharding: format.MetricSharding{Strategy: format.Tag, TagId: opt.OUint32(1)}, numShards: 16}, 2, false},
+		{"ok-by-tag-2", args{key: metric2, sharding: format.MetricSharding{Strategy: format.Tag, TagId: opt.OUint32(1)}, numShards: 16}, 6, false},
+		{"ok-by-tag-builtin", args{key: metricBuiltin, sharding: format.MetricSharding{Strategy: format.Tag, TagId: opt.OUint32(0)}, numShards: 16}, 0, false},
+
+		// negative cases
+		{"fail-fixed-no-shard", args{key: metric1, sharding: format.MetricSharding{Strategy: format.FixedShard}, numShards: 16}, 0, true},
+		{"fail-fixed-bad-shard", args{key: metric1, sharding: format.MetricSharding{Strategy: format.FixedShard, Shard: opt.OUint32(1000)}, numShards: 16}, 0, true},
+		{"fail-by-tag-no-id", args{key: metric1, sharding: format.MetricSharding{Strategy: format.Tag}, numShards: 16}, 0, true},
+		{"fail-by-tag-bad-id", args{key: metric1, sharding: format.MetricSharding{Strategy: format.Tag, TagId: opt.OUint32(1000)}, numShards: 16}, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Shard(tt.args.key, tt.args.sharding, tt.args.numShards)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Shard() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Shard() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/sharding/sharding_test.go
+++ b/internal/sharding/sharding_test.go
@@ -16,43 +16,47 @@ func TestShard(t *testing.T) {
 
 	type args struct {
 		key       data_model.Key
-		sharding  format.MetricSharding
+		meta      *format.MetricMetaValue
 		numShards int
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    uint32
-		wantErr bool
+		name             string
+		args             args
+		expectedShard    uint32
+		expectedStrategy string
+		wantErr          bool
 	}{
 		// be careful, if this tests are failing then we changed shardig schema
-		{"ok-by-tags-1", args{key: metric1, sharding: format.MetricSharding{Strategy: format.ShardByMappedTags}, numShards: 16}, 8, false},
-		{"ok-by-tags-2", args{key: metric2, sharding: format.MetricSharding{Strategy: format.ShardByMappedTags}, numShards: 16}, 15, false},
-		{"ok-by-tags-builtin", args{key: metricBuiltin, sharding: format.MetricSharding{Strategy: format.ShardByMappedTags}, numShards: 16}, 5, false},
+		{"ok-by-tags-1", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByMappedTags}}}, numShards: 16}, 8, format.ShardByMappedTags, false},
+		{"ok-by-tags-2", args{key: metric2, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByMappedTags}}}, numShards: 16}, 15, format.ShardByMappedTags, false},
+		{"ok-by-tags-builtin", args{key: metricBuiltin, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByMappedTags}}}, numShards: 16}, 5, format.ShardByMappedTags, false},
 
-		{"ok-fixed-1", args{key: metric1, sharding: format.MetricSharding{Strategy: format.ShardByFixedShard, Shard: opt.OUint32(3)}, numShards: 16}, 3, false},
-		{"ok-fixed-2", args{key: metric2, sharding: format.MetricSharding{Strategy: format.ShardByFixedShard, Shard: opt.OUint32(4)}, numShards: 16}, 4, false},
-		{"ok-fixed-builtin", args{key: metricBuiltin, sharding: format.MetricSharding{Strategy: format.ShardByFixedShard, Shard: opt.OUint32(0)}, numShards: 16}, 0, false},
+		{"ok-fixed-1", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByFixedShard, Shard: opt.OUint32(3)}}}, numShards: 16}, 3, format.ShardByFixedShard, false},
+		{"ok-fixed-2", args{key: metric2, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByFixedShard, Shard: opt.OUint32(4)}}}, numShards: 16}, 4, format.ShardByFixedShard, false},
+		{"ok-fixed-builtin", args{key: metricBuiltin, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByFixedShard, Shard: opt.OUint32(0)}}}, numShards: 16}, 0, format.ShardByFixedShard, false},
 
-		{"ok-by-tag-1", args{key: metric1, sharding: format.MetricSharding{Strategy: format.ShardByTag, TagId: opt.OUint32(1)}, numShards: 16}, 2, false},
-		{"ok-by-tag-2", args{key: metric2, sharding: format.MetricSharding{Strategy: format.ShardByTag, TagId: opt.OUint32(1)}, numShards: 16}, 6, false},
-		{"ok-by-tag-builtin", args{key: metricBuiltin, sharding: format.MetricSharding{Strategy: format.ShardByTag, TagId: opt.OUint32(0)}, numShards: 16}, 0, false},
+		{"ok-by-tag-1", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByTag, TagId: opt.OUint32(1)}}}, numShards: 16}, 2, format.ShardByTag, false},
+		{"ok-by-tag-2", args{key: metric2, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByTag, TagId: opt.OUint32(1)}}}, numShards: 16}, 6, format.ShardByTag, false},
+		{"ok-by-tag-builtin", args{key: metricBuiltin, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByTag, TagId: opt.OUint32(0)}}}, numShards: 16}, 0, format.ShardByTag, false},
 
 		// negative cases
-		{"fail-fixed-no-shard", args{key: metric1, sharding: format.MetricSharding{Strategy: format.ShardByFixedShard}, numShards: 16}, 0, true},
-		{"fail-fixed-bad-shard", args{key: metric1, sharding: format.MetricSharding{Strategy: format.ShardByFixedShard, Shard: opt.OUint32(1000)}, numShards: 16}, 0, true},
-		{"fail-by-tag-no-id", args{key: metric1, sharding: format.MetricSharding{Strategy: format.ShardByTag}, numShards: 16}, 0, true},
-		{"fail-by-tag-bad-id", args{key: metric1, sharding: format.MetricSharding{Strategy: format.ShardByTag, TagId: opt.OUint32(1000)}, numShards: 16}, 0, true},
+		{"fail-fixed-no-shard", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByFixedShard}}}, numShards: 16}, 0, "", true},
+		{"fail-fixed-bad-shard", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByFixedShard, Shard: opt.OUint32(1000)}}}, numShards: 16}, 0, "", true},
+		{"fail-by-tag-no-id", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByTag}}}, numShards: 16}, 0, "", true},
+		{"fail-by-tag-bad-id", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByTag, TagId: opt.OUint32(1000)}}}, numShards: 16}, 0, "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := Shard(tt.args.key, tt.args.sharding, tt.args.numShards)
+			gotShard, gotStrategy, err := Shard(tt.args.key, tt.args.meta, tt.args.numShards)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Shard() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != tt.want {
-				t.Errorf("Shard() = %v, want %v", got, tt.want)
+			if gotShard != tt.expectedShard {
+				t.Errorf("Shard() = %v, want %v", gotShard, tt.expectedShard)
+			}
+			if gotStrategy != tt.expectedStrategy {
+				t.Errorf("Shard() = %v, want %v", gotStrategy, tt.expectedStrategy)
 			}
 		})
 	}

--- a/internal/sharding/sharding_test.go
+++ b/internal/sharding/sharding_test.go
@@ -62,7 +62,7 @@ func TestShard(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotShard, gotStrategy, err := Shard(tt.args.key, tt.args.meta, tt.args.numShards)
+			gotShard, gotStrategy, err := Shard(tt.args.key, tt.args.meta, tt.args.numShards, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Shard() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/internal/sharding/sharding_test.go
+++ b/internal/sharding/sharding_test.go
@@ -27,21 +27,21 @@ func TestShard(t *testing.T) {
 		wantErr          bool
 	}{
 		// be careful, if this tests are failing then we changed shardig schema
-		{"ok-by-tags-1", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByMappedTags}}}, numShards: 16}, 8, format.ShardByMappedTags, false},
-		{"ok-by-tags-2", args{key: metric2, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByMappedTags}}}, numShards: 16}, 15, format.ShardByMappedTags, false},
-		{"ok-by-tags-builtin", args{key: metricBuiltin, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByMappedTags}}}, numShards: 16}, 5, format.ShardByMappedTags, false},
+		{"ok-by-tags-1", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardBy16MappedTagsHash}}}, numShards: 16}, 8, format.ShardBy16MappedTagsHash, false},
+		{"ok-by-tags-2", args{key: metric2, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardBy16MappedTagsHash}}}, numShards: 16}, 15, format.ShardBy16MappedTagsHash, false},
+		{"ok-by-tags-builtin", args{key: metricBuiltin, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardBy16MappedTagsHash}}}, numShards: 16}, 5, format.ShardBy16MappedTagsHash, false},
 
-		{"ok-fixed-1", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByFixedShard, Shard: opt.OUint32(3)}}}, numShards: 16}, 3, format.ShardByFixedShard, false},
-		{"ok-fixed-2", args{key: metric2, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByFixedShard, Shard: opt.OUint32(4)}}}, numShards: 16}, 4, format.ShardByFixedShard, false},
-		{"ok-fixed-builtin", args{key: metricBuiltin, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByFixedShard, Shard: opt.OUint32(0)}}}, numShards: 16}, 0, format.ShardByFixedShard, false},
+		{"ok-fixed-1", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardFixed, Shard: opt.OUint32(3)}}}, numShards: 16}, 3, format.ShardFixed, false},
+		{"ok-fixed-2", args{key: metric2, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardFixed, Shard: opt.OUint32(4)}}}, numShards: 16}, 4, format.ShardFixed, false},
+		{"ok-fixed-builtin", args{key: metricBuiltin, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardFixed, Shard: opt.OUint32(0)}}}, numShards: 16}, 0, format.ShardFixed, false},
 
 		{"ok-by-tag-1", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByTag, TagId: opt.OUint32(1)}}}, numShards: 16}, 2, format.ShardByTag, false},
 		{"ok-by-tag-2", args{key: metric2, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByTag, TagId: opt.OUint32(1)}}}, numShards: 16}, 6, format.ShardByTag, false},
 		{"ok-by-tag-builtin", args{key: metricBuiltin, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByTag, TagId: opt.OUint32(0)}}}, numShards: 16}, 0, format.ShardByTag, false},
 
 		// negative cases
-		{"fail-fixed-no-shard", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByFixedShard}}}, numShards: 16}, 0, "", true},
-		{"fail-fixed-bad-shard", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByFixedShard, Shard: opt.OUint32(1000)}}}, numShards: 16}, 0, "", true},
+		{"fail-fixed-no-shard", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardFixed}}}, numShards: 16}, 0, "", true},
+		{"fail-fixed-bad-shard", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardFixed, Shard: opt.OUint32(1000)}}}, numShards: 16}, 0, "", true},
 		{"fail-by-tag-no-id", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByTag}}}, numShards: 16}, 0, "", true},
 		{"fail-by-tag-bad-id", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByTag, TagId: opt.OUint32(1000)}}}, numShards: 16}, 0, "", true},
 	}

--- a/internal/sharding/sharding_test.go
+++ b/internal/sharding/sharding_test.go
@@ -17,9 +17,10 @@ func TestShard(t *testing.T) {
 	futureTs := uint32(1100)
 
 	type args struct {
-		key       data_model.Key
-		meta      *format.MetricMetaValue
-		numShards int
+		key                data_model.Key
+		meta               *format.MetricMetaValue
+		numShards          int
+		builtinNewSharding bool
 	}
 	tests := []struct {
 		name             string
@@ -29,30 +30,35 @@ func TestShard(t *testing.T) {
 		wantErr          bool
 	}{
 		// be careful, if this tests are failing then we changed shardig schema
-		{"ok-by-tags-1", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardBy16MappedTagsHash}}}, numShards: 16}, 8, format.ShardBy16MappedTagsHash, false},
-		{"ok-by-tags-2", args{key: metric2, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardBy16MappedTagsHash}}}, numShards: 16}, 15, format.ShardBy16MappedTagsHash, false},
-		{"ok-by-tags-builtin", args{key: metricBuiltin, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardBy16MappedTagsHash}}}, numShards: 16}, 5, format.ShardBy16MappedTagsHash, false},
+		{"ok-by-tags-1", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardBy16MappedTagsHash}}}, numShards: 16, builtinNewSharding: true}, 8, format.ShardBy16MappedTagsHash, false},
+		{"ok-by-tags-2", args{key: metric2, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardBy16MappedTagsHash}}}, numShards: 16, builtinNewSharding: true}, 15, format.ShardBy16MappedTagsHash, false},
+		{"ok-by-tags-builtin", args{key: metricBuiltin, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardBy16MappedTagsHash}}}, numShards: 16, builtinNewSharding: true}, 5, format.ShardBy16MappedTagsHash, false},
 
 		{"ok-multiple-after", args{key: metricBuiltin, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{
 			{Strategy: format.ShardBy16MappedTagsHash},
 			{Strategy: format.ShardFixed, Shard: opt.OUint32(0), AfterTs: opt.OUint32(futureTs)},
-		}}, numShards: 16}, 5, format.ShardBy16MappedTagsHash, false},
+		}}, numShards: 16, builtinNewSharding: true}, 5, format.ShardBy16MappedTagsHash, false},
 		{"ok-multiple-before", args{key: metricBuiltin, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{
 			{Strategy: format.ShardFixed, Shard: opt.OUint32(0)},
 			{Strategy: format.ShardBy16MappedTagsHash, AfterTs: opt.OUint32(pastTs)},
-		}}, numShards: 16}, 5, format.ShardBy16MappedTagsHash, false},
+		}}, numShards: 16, builtinNewSharding: true}, 5, format.ShardBy16MappedTagsHash, false},
 		{"ok-multiple-no-ts", args{key: metricBuiltin, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{
 			{Strategy: format.ShardFixed, Shard: opt.OUint32(0)},
 			{Strategy: format.ShardBy16MappedTagsHash},
-		}}, numShards: 16}, 5, format.ShardBy16MappedTagsHash, false},
+		}}, numShards: 16, builtinNewSharding: true}, 5, format.ShardBy16MappedTagsHash, false},
 
-		{"ok-fixed-1", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardFixed, Shard: opt.OUint32(3)}}}, numShards: 16}, 3, format.ShardFixed, false},
-		{"ok-fixed-2", args{key: metric2, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardFixed, Shard: opt.OUint32(4)}}}, numShards: 16}, 4, format.ShardFixed, false},
-		{"ok-fixed-builtin", args{key: metricBuiltin, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardFixed, Shard: opt.OUint32(0)}}}, numShards: 16}, 0, format.ShardFixed, false},
+		{"ok-fixed-1", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardFixed, Shard: opt.OUint32(3)}}}, numShards: 16, builtinNewSharding: true}, 3, format.ShardFixed, false},
+		{"ok-fixed-2", args{key: metric2, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardFixed, Shard: opt.OUint32(4)}}}, numShards: 16, builtinNewSharding: true}, 4, format.ShardFixed, false},
+		{"ok-fixed-builtin", args{key: metricBuiltin, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardFixed, Shard: opt.OUint32(0)}}}, numShards: 16, builtinNewSharding: true}, 0, format.ShardFixed, false},
 
-		{"ok-by-tag-1", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByTag, TagId: opt.OUint32(1)}}}, numShards: 16}, 2, format.ShardByTag, false},
-		{"ok-by-tag-2", args{key: metric2, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByTag, TagId: opt.OUint32(1)}}}, numShards: 16}, 6, format.ShardByTag, false},
-		{"ok-by-tag-builtin", args{key: metricBuiltin, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByTag, TagId: opt.OUint32(0)}}}, numShards: 16}, 0, format.ShardByTag, false},
+		{"ok-by-tag-1", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByTag, TagId: opt.OUint32(1)}}}, numShards: 16, builtinNewSharding: true}, 2, format.ShardByTag, false},
+		{"ok-by-tag-2", args{key: metric2, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByTag, TagId: opt.OUint32(1)}}}, numShards: 16, builtinNewSharding: true}, 6, format.ShardByTag, false},
+		{"ok-by-tag-builtin", args{key: metricBuiltin, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByTag, TagId: opt.OUint32(0)}}}, numShards: 16, builtinNewSharding: true}, 0, format.ShardByTag, false},
+
+		{"ok-by-metric-id", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardByMetricId}}}, numShards: 16, builtinNewSharding: true}, 1, format.ShardByMetricId, false},
+
+		{"builing-flag-builtin", args{key: metricBuiltin, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardFixed, Shard: opt.OUint32(0)}}}, numShards: 16, builtinNewSharding: false}, 5, format.ShardBy16MappedTagsHash, false},
+		{"builing-flag-user-metric", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardFixed, Shard: opt.OUint32(3)}}}, numShards: 16, builtinNewSharding: false}, 3, format.ShardFixed, false},
 
 		// negative cases
 		{"fail-fixed-no-shard", args{key: metric1, meta: &format.MetricMetaValue{Sharding: []format.MetricSharding{{Strategy: format.ShardFixed}}}, numShards: 16}, 0, "", true},
@@ -62,7 +68,7 @@ func TestShard(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotShard, gotStrategy, err := Shard(tt.args.key, tt.args.meta, tt.args.numShards, false)
+			gotShard, gotStrategy, err := Shard(tt.args.key, tt.args.meta, tt.args.numShards, tt.args.builtinNewSharding)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Shard() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
There are two main parts:
1. for user metrics we now use strategy from meta info
   - plan is to update them as agent are deployed
2. for builtin metric we use hard-coded strategy: everything in 0 shard except for ingestion and badges which are sharded by metric tag
