### PR TITLE
Agent refactoring

### DIFF
--- a/cmd/statshouse/shutdown_info.go
+++ b/cmd/statshouse/shutdown_info.go
@@ -30,53 +30,53 @@ func shutdownInfoReport(sh2 *agent.Agent, componentTag int32, storageDir string,
 	if dur := globalStartTime.Sub(finishShutdownTime); si.FinishShutdownTime > 0 && dur > 0 && dur < time.Hour {
 		// arbitrary check that if start took more than 1 hour, this was not restart, and we do not want such case in our averages
 		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
-			Keys: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseInactive}},
+			Tags: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseInactive}},
 			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	if dur := time.Duration(si.StopRecentSenders); dur > 0 {
 		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
-			Keys: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopRecentSenders}},
+			Tags: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopRecentSenders}},
 			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	if dur := time.Duration(si.StopReceivers); dur > 0 {
 		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
-			Keys: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopReceivers}},
+			Tags: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopReceivers}},
 			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	if dur := time.Duration(si.StopFlusher); dur > 0 {
 		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
-			Keys: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopFlusher}},
+			Tags: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopFlusher}},
 			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	if dur := time.Duration(si.StopFlushing); dur > 0 {
 		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
-			Keys: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopFlushing}},
+			Tags: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopFlushing}},
 			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	if dur := time.Duration(si.StopPreprocessor); dur > 0 {
 		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
-			Keys: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopPreprocessor}},
+			Tags: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopPreprocessor}},
 			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	if dur := time.Duration(si.StopInserters); dur > 0 {
 		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
-			Keys: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopInserters}},
+			Tags: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopInserters}},
 			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	if dur := time.Duration(si.StopRPCServer); dur > 0 {
 		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
-			Keys: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopRPCServer}},
+			Tags: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopRPCServer}},
 			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	finishLoadingTime := time.Now()
 	if dur := startDiscCache.Sub(globalStartTime); dur > 0 {
 		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
-			Keys: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStartDiskCache}},
+			Tags: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStartDiskCache}},
 			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	if dur := finishLoadingTime.Sub(startDiscCache); dur > 0 {
 		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
-			Keys: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStartService}},
+			Tags: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStartService}},
 			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 
@@ -84,7 +84,7 @@ func shutdownInfoReport(sh2 *agent.Agent, componentTag int32, storageDir string,
 	if dur := finishLoadingTime.Sub(startShutdownTime); si.StartShutdownTime > 0 && dur > 0 && dur < time.Hour {
 		// arbitrary check that if start took more than 1 hour, this was not restart, and we do not want such case in our averages
 		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
-			Keys: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseTotal}},
+			Tags: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseTotal}},
 			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 		logOk.Printf("restart finished in %v (since shutdown start time recorded by previous instance)", dur)
 	} else {

--- a/cmd/statshouse/statshouse-tools.go
+++ b/cmd/statshouse/statshouse-tools.go
@@ -317,7 +317,7 @@ func FakeBenchmarkMetricsPerSecond(listenAddr string) {
 				if almostReceiveOnly && r%1024 != 0 {
 					return h, true
 				}
-				h, done = mapper.Map(data_model.HandlerArgs{MetricBytes: m, MapCallback: cb}, metricStorage.GetMetaMetricByNameBytes(m.Name))
+				done = mapper.Map(data_model.HandlerArgs{MetricBytes: m, MapCallback: cb}, metricStorage.GetMetaMetricByNameBytes(m.Name), &h)
 				if done {
 					handleMappedMetric(*m, h)
 				}

--- a/cmd/statshouse/statshouse-tools.go
+++ b/cmd/statshouse/statshouse-tools.go
@@ -244,7 +244,7 @@ func FakeBenchmarkMetricsPerSecond(listenAddr string) {
 			wrongID.Inc()
 			return
 		}
-		if testFastPath && h.Key.Keys[1] != 1 {
+		if testFastPath && h.Key.Tags[1] != 1 {
 			wrongTag1.Inc()
 			return
 		}

--- a/cmd/statshouse/statshouse.go
+++ b/cmd/statshouse/statshouse.go
@@ -295,7 +295,7 @@ func mainAgent(aesPwd string, dc *pcache.DiskCache) int {
 			if dc != nil {
 				s, err := dc.DiskSizeBytes()
 				if err == nil {
-					a.AddValueCounter(data_model.Key{Timestamp: unixNow, Metric: format.BuiltinMetricIDAgentDiskCacheSize, Keys: [16]int32{0, 0, 0}}, float64(s), 1, format.BuiltinMetricMetaAgentDiskCacheSize)
+					a.AddValueCounter(data_model.Key{Timestamp: unixNow, Metric: format.BuiltinMetricIDAgentDiskCacheSize, Tags: [16]int32{0, 0, 0}}, float64(s), 1, format.BuiltinMetricMetaAgentDiskCacheSize)
 				}
 			}
 		},

--- a/cmd/statshouse/worker.go
+++ b/cmd/statshouse/worker.go
@@ -58,10 +58,12 @@ func (w *worker) HandleMetrics(args data_model.HandlerArgs) (h data_model.Mapped
 	}
 	w.fillTime(args, &h)
 	if done = w.getMetricMeta(args, &h); done {
+		w.mapper.MapEnvironment(args.MetricBytes, &h)
 		return h, done
 	}
 	h.Key.Metric = h.MetricInfo.MetricID
 	if !h.MetricInfo.Visible {
+		w.mapper.MapEnvironment(args.MetricBytes, &h)
 		h.IngestionStatus = format.TagValueIDSrcIngestionStatusErrMetricInvisible
 		return h, true
 	}

--- a/cmd/statshouse/worker.go
+++ b/cmd/statshouse/worker.go
@@ -59,11 +59,11 @@ func (w *worker) HandleMetrics(args data_model.HandlerArgs) (h data_model.Mapped
 	w.fillTime(args, &h)
 	metaOk := w.fillMetricMeta(args, &h)
 	if metaOk {
-		h.Key.Metric = h.MetricInfo.MetricID
-		if !h.MetricInfo.Visible {
+		h.Key.Metric = h.MetricMeta.MetricID
+		if !h.MetricMeta.Visible {
 			h.IngestionStatus = format.TagValueIDSrcIngestionStatusErrMetricInvisible
 		}
-		done = w.mapper.Map(args, h.MetricInfo, &h)
+		done = w.mapper.Map(args, h.MetricMeta, &h)
 	} else {
 		w.mapper.MapEnvironment(args.MetricBytes, &h)
 		done = true
@@ -93,12 +93,12 @@ func (w *worker) fillMetricMeta(args data_model.HandlerArgs, h *data_model.Mappe
 	metric := args.MetricBytes
 	metricMeta := w.metricStorage.GetMetaMetricByNameBytes(metric.Name)
 	if metricMeta != nil {
-		h.MetricInfo = metricMeta
+		h.MetricMeta = metricMeta
 		return true
 	}
 	metricMeta = format.BuiltinMetricAllowedToReceive[string(metric.Name)]
 	if metricMeta != nil {
-		h.MetricInfo = metricMeta
+		h.MetricMeta = metricMeta
 		return true
 	}
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -241,14 +241,14 @@ func MakeAgent(network string, storageDir string, aesPwd string, config Config, 
 	}
 
 	// TODO - remove those, simply write metrics to bucket as usual
-	result.statErrorsDiskWrite = result.CreateBuiltInItemValue(data_model.Key{Metric: format.BuiltinMetricIDAgentDiskCacheErrors, Keys: [16]int32{0, format.TagValueIDDiskCacheErrorWrite}}, format.BuiltinMetricMetaAgentDiskCacheErrors)
-	result.statErrorsDiskRead = result.CreateBuiltInItemValue(data_model.Key{Metric: format.BuiltinMetricIDAgentDiskCacheErrors, Keys: [16]int32{0, format.TagValueIDDiskCacheErrorRead}}, format.BuiltinMetricMetaAgentDiskCacheErrors)
-	result.statErrorsDiskErase = result.CreateBuiltInItemValue(data_model.Key{Metric: format.BuiltinMetricIDAgentDiskCacheErrors, Keys: [16]int32{0, format.TagValueIDDiskCacheErrorDelete}}, format.BuiltinMetricMetaAgentDiskCacheErrors)
-	result.statErrorsDiskReadNotConfigured = result.CreateBuiltInItemValue(data_model.Key{Metric: format.BuiltinMetricIDAgentDiskCacheErrors, Keys: [16]int32{0, format.TagValueIDDiskCacheErrorReadNotConfigured}}, format.BuiltinMetricMetaAgentDiskCacheErrors)
-	result.statErrorsDiskCompressFailed = result.CreateBuiltInItemValue(data_model.Key{Metric: format.BuiltinMetricIDAgentDiskCacheErrors, Keys: [16]int32{0, format.TagValueIDDiskCacheErrorCompressFailed}}, format.BuiltinMetricMetaAgentDiskCacheErrors)
-	result.statLongWindowOverflow = result.CreateBuiltInItemValue(data_model.Key{Metric: format.BuiltinMetricIDTimingErrors, Keys: [16]int32{0, format.TagValueIDTimingLongWindowThrownAgent}}, format.BuiltinMetricMetaTimingErrors)
-	result.statDiskOverflow = result.CreateBuiltInItemValue(data_model.Key{Metric: format.BuiltinMetricIDTimingErrors, Keys: [16]int32{0, format.TagValueIDTimingLongWindowThrownAgent}}, format.BuiltinMetricMetaTimingErrors)
-	result.statMemoryOverflow = result.CreateBuiltInItemValue(data_model.Key{Metric: format.BuiltinMetricIDTimingErrors, Keys: [16]int32{0, format.TagValueIDTimingThrownDueToMemory}}, format.BuiltinMetricMetaTimingErrors)
+	result.statErrorsDiskWrite = result.CreateBuiltInItemValue(data_model.Key{Metric: format.BuiltinMetricIDAgentDiskCacheErrors, Tags: [16]int32{0, format.TagValueIDDiskCacheErrorWrite}}, format.BuiltinMetricMetaAgentDiskCacheErrors)
+	result.statErrorsDiskRead = result.CreateBuiltInItemValue(data_model.Key{Metric: format.BuiltinMetricIDAgentDiskCacheErrors, Tags: [16]int32{0, format.TagValueIDDiskCacheErrorRead}}, format.BuiltinMetricMetaAgentDiskCacheErrors)
+	result.statErrorsDiskErase = result.CreateBuiltInItemValue(data_model.Key{Metric: format.BuiltinMetricIDAgentDiskCacheErrors, Tags: [16]int32{0, format.TagValueIDDiskCacheErrorDelete}}, format.BuiltinMetricMetaAgentDiskCacheErrors)
+	result.statErrorsDiskReadNotConfigured = result.CreateBuiltInItemValue(data_model.Key{Metric: format.BuiltinMetricIDAgentDiskCacheErrors, Tags: [16]int32{0, format.TagValueIDDiskCacheErrorReadNotConfigured}}, format.BuiltinMetricMetaAgentDiskCacheErrors)
+	result.statErrorsDiskCompressFailed = result.CreateBuiltInItemValue(data_model.Key{Metric: format.BuiltinMetricIDAgentDiskCacheErrors, Tags: [16]int32{0, format.TagValueIDDiskCacheErrorCompressFailed}}, format.BuiltinMetricMetaAgentDiskCacheErrors)
+	result.statLongWindowOverflow = result.CreateBuiltInItemValue(data_model.Key{Metric: format.BuiltinMetricIDTimingErrors, Tags: [16]int32{0, format.TagValueIDTimingLongWindowThrownAgent}}, format.BuiltinMetricMetaTimingErrors)
+	result.statDiskOverflow = result.CreateBuiltInItemValue(data_model.Key{Metric: format.BuiltinMetricIDTimingErrors, Tags: [16]int32{0, format.TagValueIDTimingLongWindowThrownAgent}}, format.BuiltinMetricMetaTimingErrors)
+	result.statMemoryOverflow = result.CreateBuiltInItemValue(data_model.Key{Metric: format.BuiltinMetricIDTimingErrors, Tags: [16]int32{0, format.TagValueIDTimingThrownDueToMemory}}, format.BuiltinMetricMetaTimingErrors)
 
 	result.updateConfigRemotelyExperimental() // first update from stored in sqlite
 	return result, nil
@@ -507,7 +507,7 @@ func (s *Agent) ApplyMetric(m tlstatshouse.MetricBytes, h data_model.MappedMetri
 		// In case of utf decoding error, it contains hex representation of original string
 		s.AddCounterHostStringBytes(data_model.Key{
 			Metric: format.BuiltinMetricIDIngestionStatus,
-			Keys:   [format.MaxTags]int32{h.Key.Keys[0], h.Key.Metric, h.IngestionStatus, h.IngestionTagKey},
+			Tags:   [format.MaxTags]int32{h.Key.Tags[0], h.Key.Metric, h.IngestionStatus, h.IngestionTagKey},
 		}, h.InvalidString, 1, 0, format.BuiltinMetricMetaIngestionStatus)
 		return
 	}
@@ -516,14 +516,14 @@ func (s *Agent) ApplyMetric(m tlstatshouse.MetricBytes, h data_model.MappedMetri
 	if err != nil {
 		s.AddCounter(data_model.Key{
 			Metric: format.BuiltinMetricIDIngestionStatus,
-			Keys:   [format.MaxTags]int32{h.Key.Keys[0], h.Key.Metric, format.TagValueIDSrcIngestionStatusErrShardingFailed, h.IngestionTagKey},
+			Tags:   [format.MaxTags]int32{h.Key.Tags[0], h.Key.Metric, format.TagValueIDSrcIngestionStatusErrShardingFailed, h.IngestionTagKey},
 		}, 1, format.BuiltinMetricMetaIngestionStatus)
 		return
 	}
 	// now set ok status
 	s.AddCounter(data_model.Key{
 		Metric: format.BuiltinMetricIDIngestionStatus,
-		Keys:   [format.MaxTags]int32{h.Key.Keys[0], h.Key.Metric, ingestionStatusOKTag, h.IngestionTagKey},
+		Tags:   [format.MaxTags]int32{h.Key.Tags[0], h.Key.Metric, ingestionStatusOKTag, h.IngestionTagKey},
 	}, 1, format.BuiltinMetricMetaIngestionStatus)
 	// now set all warnings
 	if h.NotFoundTagName != nil { // this is correct, can be set, but empty
@@ -531,7 +531,7 @@ func (s *Agent) ApplyMetric(m tlstatshouse.MetricBytes, h data_model.MappedMetri
 		// This is warning, so written independent of ingestion status
 		s.AddCounterHostStringBytes(data_model.Key{
 			Metric: format.BuiltinMetricIDIngestionStatus,
-			Keys:   [format.MaxTags]int32{h.Key.Keys[0], h.Key.Metric, format.TagValueIDSrcIngestionStatusWarnMapTagNameNotFound}, // tag ID not known
+			Tags:   [format.MaxTags]int32{h.Key.Tags[0], h.Key.Metric, format.TagValueIDSrcIngestionStatusWarnMapTagNameNotFound}, // tag ID not known
 		}, h.NotFoundTagName, 1, 0, format.BuiltinMetricMetaIngestionStatus)
 	}
 	if h.FoundDraftTagName != nil { // this is correct, can be set, but empty
@@ -539,25 +539,25 @@ func (s *Agent) ApplyMetric(m tlstatshouse.MetricBytes, h data_model.MappedMetri
 		// This is warning, so written independent of ingestion status
 		s.AddCounterHostStringBytes(data_model.Key{
 			Metric: format.BuiltinMetricIDIngestionStatus,
-			Keys:   [format.MaxTags]int32{h.Key.Keys[0], h.Key.Metric, format.TagValueIDSrcIngestionStatusWarnMapTagNameFoundDraft}, // tag ID is known, but draft
+			Tags:   [format.MaxTags]int32{h.Key.Tags[0], h.Key.Metric, format.TagValueIDSrcIngestionStatusWarnMapTagNameFoundDraft}, // tag ID is known, but draft
 		}, h.FoundDraftTagName, 1, 0, format.BuiltinMetricMetaIngestionStatus)
 	}
 	if h.TagSetTwiceKey != 0 {
 		s.AddCounter(data_model.Key{
 			Metric: format.BuiltinMetricIDIngestionStatus,
-			Keys:   [format.MaxTags]int32{h.Key.Keys[0], h.Key.Metric, format.TagValueIDSrcIngestionStatusWarnMapTagSetTwice, h.TagSetTwiceKey},
+			Tags:   [format.MaxTags]int32{h.Key.Tags[0], h.Key.Metric, format.TagValueIDSrcIngestionStatusWarnMapTagSetTwice, h.TagSetTwiceKey},
 		}, 1, format.BuiltinMetricMetaIngestionStatus)
 	}
 	if h.InvalidRawTagKey != 0 {
 		s.AddCounterHostStringBytes(data_model.Key{
 			Metric: format.BuiltinMetricIDIngestionStatus,
-			Keys:   [format.MaxTags]int32{h.Key.Keys[0], h.Key.Metric, format.TagValueIDSrcIngestionStatusWarnMapInvalidRawTagValue, h.InvalidRawTagKey},
+			Tags:   [format.MaxTags]int32{h.Key.Tags[0], h.Key.Metric, format.TagValueIDSrcIngestionStatusWarnMapInvalidRawTagValue, h.InvalidRawTagKey},
 		}, h.InvalidRawValue, 1, 0, format.BuiltinMetricMetaIngestionStatus)
 	}
 	if h.LegacyCanonicalTagKey != 0 {
 		s.AddCounter(data_model.Key{
 			Metric: format.BuiltinMetricIDIngestionStatus,
-			Keys:   [format.MaxTags]int32{h.Key.Keys[0], h.Key.Metric, format.TagValueIDSrcIngestionStatusWarnDeprecatedKeyName, h.LegacyCanonicalTagKey},
+			Tags:   [format.MaxTags]int32{h.Key.Tags[0], h.Key.Metric, format.TagValueIDSrcIngestionStatusWarnDeprecatedKeyName, h.LegacyCanonicalTagKey},
 		}, 1, format.BuiltinMetricMetaIngestionStatus)
 	}
 

--- a/internal/agent/agent_loaders.go
+++ b/internal/agent/agent_loaders.go
@@ -173,7 +173,7 @@ func (s *Agent) LoadMetaMetricJournal(ctxParent context.Context, version int64, 
 	// On the other hand, if aggregators cannot map, but can insert, system is working
 	// So, we must have separate live-dead status for mappings - TODO
 	if s0 == nil {
-		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusAllDead}}, 0, 1, format.BuiltinMetricMetaAgentMapping)
+		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Tags: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusAllDead}}, 0, 1, format.BuiltinMetricMetaAgentMapping)
 		return nil, version, fmt.Errorf("cannot load meta journal, all aggregators are dead")
 	}
 	now := time.Now()
@@ -189,7 +189,7 @@ func (s *Agent) LoadMetaMetricJournal(ctxParent context.Context, version int64, 
 	// We do not need timeout for long poll, RPC has disconnect detection via ping-pong
 	err := s0.client.GetMetrics3(ctxParent, args, &extra, &ret)
 	if err != nil {
-		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusErrSingle}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
+		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Tags: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusErrSingle}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
 		return nil, version, fmt.Errorf("cannot load meta journal - %w", err)
 	}
 	/*
@@ -197,7 +197,7 @@ func (s *Agent) LoadMetaMetricJournal(ctxParent context.Context, version int64, 
 				s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusErrSingle}}, time.Since(now).Seconds(), 1, false, format.BuiltinMetricIDAgentMapping)
 		}
 	*/
-	s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusOKFirst}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
+	s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Tags: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusOKFirst}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
 	return ret.Events, ret.CurrentVersion, nil
 }
 
@@ -206,7 +206,7 @@ func (s *Agent) LoadOrCreateMapping(ctxParent context.Context, key string, flood
 	// Use 2 alive random aggregators for mapping
 	s0, s1 := s.getRandomLiveShardReplicas()
 	if s0 == nil {
-		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusAllDead}}, 0, 1, format.BuiltinMetricMetaAgentMapping)
+		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Tags: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusAllDead}}, 0, 1, format.BuiltinMetricMetaAgentMapping)
 		return nil, 0, fmt.Errorf("all aggregators are dead")
 	}
 	now := time.Now()
@@ -232,11 +232,11 @@ func (s *Agent) LoadOrCreateMapping(ctxParent context.Context, key string, flood
 	defer cancel()
 	err := s0.client.GetTagMapping2(ctx, args, &extra, &ret)
 	if err == nil {
-		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusOKFirst}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
+		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Tags: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusOKFirst}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
 		return pcache.Int32ToValue(ret.Value), time.Duration(ret.TtlNanosec), nil
 	}
 	if s1 == nil {
-		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusErrSingle}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
+		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Tags: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusErrSingle}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
 		return nil, 0, fmt.Errorf("the only live aggregator %q returned error: %w", s0.client.Address, err)
 	}
 
@@ -246,10 +246,10 @@ func (s *Agent) LoadOrCreateMapping(ctxParent context.Context, key string, flood
 	defer cancel2()
 	err2 := s1.client.GetTagMapping2(ctx2, args, &extra, &ret)
 	if err2 == nil {
-		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusOKSecond}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
+		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Tags: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusOKSecond}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
 		return pcache.Int32ToValue(ret.Value), time.Duration(ret.TtlNanosec), nil
 	}
-	s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusErrBoth}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
+	s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Tags: [16]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusErrBoth}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
 	return nil, 0, fmt.Errorf("two live aggregators %q %q returned errors: %v %w", s0.client.Address, s1.client.Address, err, err2)
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -33,28 +33,6 @@ func Benchmark_Hash(b *testing.B) {
 	}
 }
 
-func Benchmark_HashSafe(b *testing.B) {
-	var k data_model.Key
-	var result uint64
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		k.Tags[14]++
-		k.Tags[0] = int32(i)
-		result += k.HashSafe()
-	}
-}
-
-func Test_HashSafeUnsafe(t *testing.T) {
-	var k data_model.Key
-	for i := 0; i < 1000; i++ {
-		k.Tags[14]++
-		k.Tags[0] = int32(i)
-		if k.Hash() != k.HashSafe() {
-			t.Fail()
-		}
-	}
-}
-
 func Test_BelieveTimestampWindow(t *testing.T) {
 	// we shift rounded time by this amount in func (s *Shard) resolutionShardFromHashLocked,
 	// so it must be multiple of 60.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -27,8 +27,8 @@ func Benchmark_Hash(b *testing.B) {
 	var result uint64
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		k.Keys[14]++
-		k.Keys[0] = int32(i)
+		k.Tags[14]++
+		k.Tags[0] = int32(i)
 		result += k.Hash()
 	}
 }
@@ -38,8 +38,8 @@ func Benchmark_HashSafe(b *testing.B) {
 	var result uint64
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		k.Keys[14]++
-		k.Keys[0] = int32(i)
+		k.Tags[14]++
+		k.Tags[0] = int32(i)
 		result += k.HashSafe()
 	}
 }
@@ -47,8 +47,8 @@ func Benchmark_HashSafe(b *testing.B) {
 func Test_HashSafeUnsafe(t *testing.T) {
 	var k data_model.Key
 	for i := 0; i < 1000; i++ {
-		k.Keys[14]++
-		k.Keys[0] = int32(i)
+		k.Tags[14]++
+		k.Tags[0] = int32(i)
 		if k.Hash() != k.HashSafe() {
 			t.Fail()
 		}
@@ -173,8 +173,8 @@ func Benchmark_SampleFactor(b *testing.B) {
 	var result uint64
 	for i := 0; i < b.N; i++ {
 		k.Metric = int32(i & 2047)
-		k.Keys[14]++
-		k.Keys[0] = int32(i)
+		k.Tags[14]++
+		k.Tags[0] = int32(i)
 		_, ok := data_model.SampleFactor(rnd, sampleFactors, k.Metric)
 		if ok {
 			result++
@@ -192,8 +192,8 @@ func Benchmark_sampleFactorDeterministic(b *testing.B) {
 	var result uint64
 	for i := 0; i < b.N; i++ {
 		k.Metric = int32(i & 2047)
-		k.Keys[14]++
-		k.Keys[0] = int32(i)
+		k.Tags[14]++
+		k.Tags[0] = int32(i)
 		_, ok := data_model.SampleFactorDeterministic(sampleFactors, k, uint32(i))
 		if ok {
 			result++
@@ -300,11 +300,11 @@ func randKey(rng *rand.Rand, ts uint32, metricOffset int32) data_model.Key {
 	key := data_model.Key{
 		Timestamp: ts,
 		Metric:    metricOffset + rng.Int31n(100_000),
-		Keys:      [16]int32{},
+		Tags:      [16]int32{},
 	}
 	tagsN := rng.Int31n(16)
 	for t := 0; t < int(tagsN); t++ {
-		key.Keys[t] = rng.Int31n(100_000)
+		key.Tags[t] = rng.Int31n(100_000)
 	}
 	return key
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -281,7 +281,7 @@ func Benchmark_AgentApplyMetric(b *testing.B) {
 		Value:   make([]float64, 1),
 	}
 	h := data_model.MappedMetricHeader{
-		MetricInfo: &format.MetricMetaValue{
+		MetricMeta: &format.MetricMetaValue{
 			EffectiveResolution: 1,
 			Sharding:            []format.MetricSharding{{Strategy: format.ShardBy16MappedTagsHash}},
 		},
@@ -321,11 +321,11 @@ func applyRandCountMetric(a *Agent, rng *rand.Rand, ts uint32, offset int32, upd
 	key := randKey(rng, ts, offset)
 	h := data_model.MappedMetricHeader{
 		Key: key,
-		MetricInfo: &format.MetricMetaValue{
+		MetricMeta: &format.MetricMetaValue{
 			EffectiveResolution: randResolution(rng),
 		},
 	}
-	h.MetricInfo = updateMeta(h.MetricInfo, key)
+	h.MetricMeta = updateMeta(h.MetricMeta, key)
 	a.ApplyMetric(m, h, format.TagValueIDAggMappingStatusOKCached)
 }
 
@@ -341,11 +341,11 @@ func applyRandValueMetric(a *Agent, rng *rand.Rand, ts uint32, offset int32, upd
 	key := randKey(rng, ts, offset)
 	h := data_model.MappedMetricHeader{
 		Key: key,
-		MetricInfo: &format.MetricMetaValue{
+		MetricMeta: &format.MetricMetaValue{
 			EffectiveResolution: randResolution(rng),
 		},
 	}
-	h.MetricInfo = updateMeta(h.MetricInfo, key)
+	h.MetricMeta = updateMeta(h.MetricMeta, key)
 	a.ApplyMetric(m, h, format.TagValueIDAggMappingStatusOKCached)
 }
 
@@ -361,12 +361,12 @@ func applyRandUniqueMetric(a *Agent, rng *rand.Rand, ts uint32, offset int32, up
 	key := randKey(rng, ts, offset)
 	h := data_model.MappedMetricHeader{
 		Key: key,
-		MetricInfo: &format.MetricMetaValue{
+		MetricMeta: &format.MetricMetaValue{
 			EffectiveResolution: randResolution(rng),
 			ShardUniqueValues:   false, // for predictability of total sum in shards
 		},
 	}
-	h.MetricInfo = updateMeta(h.MetricInfo, key)
+	h.MetricMeta = updateMeta(h.MetricMeta, key)
 	a.ApplyMetric(m, h, format.TagValueIDAggMappingStatusOKCached)
 }
 

--- a/internal/aggregator/aggregator_handlers.go
+++ b/internal/aggregator/aggregator_handlers.go
@@ -41,11 +41,11 @@ func (a *Aggregator) handleClient(ctx context.Context, hctx *rpc.HandlerContext)
 	key := a.aggKey(uint32(hctx.RequestTime.Unix()), format.BuiltinMetricIDRPCRequests, [16]int32{0, format.TagValueIDComponentAggregator, int32(tag), format.TagValueIDRPCRequestsStatusOK, 0, 0, keyIDTag, 0, protocol})
 	err := a.h.Handle(ctx, hctx)
 	if err == rpc.ErrNoHandler {
-		key.Keys[3] = format.TagValueIDRPCRequestsStatusNoHandler
+		key.Tags[3] = format.TagValueIDRPCRequestsStatusNoHandler
 	} else if rpc.IsHijackedResponse(err) {
-		key.Keys[3] = format.TagValueIDRPCRequestsStatusHijack
+		key.Tags[3] = format.TagValueIDRPCRequestsStatusHijack
 	} else if err != nil {
-		key.Keys[3] = format.TagValueIDRPCRequestsStatusErrLocal
+		key.Tags[3] = format.TagValueIDRPCRequestsStatusErrLocal
 	}
 	a.sh2.AddValueCounter(key, float64(requestLen), 1, format.BuiltinMetricMetaRPCRequests)
 	return err
@@ -319,37 +319,37 @@ func (a *Aggregator) handleSendSourceBucket2(_ context.Context, hctx *rpc.Handle
 			if k.Metric == format.BuiltinMetricIDAgentHeartbeatVersion {
 				// Remap legacy metric to a new one
 				k.Metric = format.BuiltinMetricIDHeartbeatVersion
-				k.Keys[2] = k.Keys[1]
-				k.Keys[1] = format.TagValueIDComponentAgent
+				k.Tags[2] = k.Tags[1]
+				k.Tags[1] = format.TagValueIDComponentAgent
 			}
 			if k.Metric == format.BuiltinMetricIDAgentHeartbeatArgs {
 				// Remap legacy metric to a new one
 				k.Metric = format.BuiltinMetricIDHeartbeatArgs
-				k.Keys[2] = k.Keys[1]
-				k.Keys[1] = format.TagValueIDComponentAgent
+				k.Tags[2] = k.Tags[1]
+				k.Tags[1] = format.TagValueIDComponentAgent
 			}
 			if k.Metric == format.BuiltinMetricIDHeartbeatVersion ||
 				k.Metric == format.BuiltinMetricIDHeartbeatArgs {
 				// In case of agent we need to set IP anyway, so set other keys here, not by source
 				// In case of api other tags are already set, so don't overwrite them
-				if k.Keys[4] == 0 {
-					k.Keys[4] = bcTag
+				if k.Tags[4] == 0 {
+					k.Tags[4] = bcTag
 				}
-				if k.Keys[5] == 0 {
-					k.Keys[5] = args.BuildCommitDate
+				if k.Tags[5] == 0 {
+					k.Tags[5] = args.BuildCommitDate
 				}
-				if k.Keys[6] == 0 {
-					k.Keys[6] = args.BuildCommitTs
+				if k.Tags[6] == 0 {
+					k.Tags[6] = args.BuildCommitTs
 				}
-				if k.Keys[7] == 0 {
-					k.Keys[7] = hostTagId
+				if k.Tags[7] == 0 {
+					k.Tags[7] = hostTagId
 				}
 				// Valid for api as well because it is on the same host as agent
-				k.Keys[8] = int32(addrIPV4)
-				k.Keys[9] = owner
+				k.Tags[8] = int32(addrIPV4)
+				k.Tags[9] = owner
 			}
 			if k.Metric == format.BuiltinMetricIDRPCRequests {
-				k.Keys[7] = hostTagId // agent cannot easily map its own host for now
+				k.Tags[7] = hostTagId // agent cannot easily map its own host for now
 			}
 		}
 		s := aggBucket.lockShard(&lockedShard, sID)
@@ -439,7 +439,7 @@ func (a *Aggregator) handleSendSourceBucket2(_ context.Context, hctx *rpc.Handle
 	}
 
 	ingestionStatus := func(env int32, metricID int32, status int32, value float32) {
-		data_model.MapKeyItemMultiItem(&s.multiItems, (data_model.Key{Timestamp: args.Time, Metric: format.BuiltinMetricIDIngestionStatus, Keys: [16]int32{env, metricID, status}}).WithAgentEnvRouteArch(agentEnv, route, buildArch), data_model.AggregatorStringTopCapacity, nil, nil).Tail.AddCounterHost(rng, float64(value), hostTagId)
+		data_model.MapKeyItemMultiItem(&s.multiItems, (data_model.Key{Timestamp: args.Time, Metric: format.BuiltinMetricIDIngestionStatus, Tags: [16]int32{env, metricID, status}}).WithAgentEnvRouteArch(agentEnv, route, buildArch), data_model.AggregatorStringTopCapacity, nil, nil).Tail.AddCounterHost(rng, float64(value), hostTagId)
 	}
 	for _, v := range bucket.IngestionStatusOk {
 		// We do not split by aggregator, because this metric is taking already too much space - about 1% of all data

--- a/internal/aggregator/aggregator_insert.go
+++ b/internal/aggregator/aggregator_insert.go
@@ -132,7 +132,7 @@ func appendKeys(res []byte, k data_model.Key, metricCache *metricIndexCache, use
 	res = binary.LittleEndian.AppendUint32(res, uint32(k.Metric))
 	prekeyIndex, prekeyOnly := metricCache.getPrekeyIndex(k.Metric)
 	if prekeyIndex >= 0 {
-		res = binary.LittleEndian.AppendUint32(res, uint32(k.Keys[prekeyIndex]))
+		res = binary.LittleEndian.AppendUint32(res, uint32(k.Tags[prekeyIndex]))
 		if prekeyOnly {
 			res = append(res, byte(2))
 		} else {
@@ -148,7 +148,7 @@ func appendKeys(res []byte, k data_model.Key, metricCache *metricIndexCache, use
 	}
 	tagsN := format.MaxTags
 	for ki := 0; ki < tagsN; ki++ {
-		res = appendTag(res, uint32(k.Keys[ki]))
+		res = appendTag(res, uint32(k.Tags[ki]))
 	}
 	return res
 }
@@ -179,8 +179,8 @@ func appendKeysNewFormat(res []byte, k data_model.Key, metricCache *metricIndexC
 			res = rowbinary.AppendString(res, stag)
 			continue
 		}
-		if ki < len(k.Keys) {
-			res = appendTag(res, uint32(k.Keys[ki]))
+		if ki < len(k.Tags) {
+			res = appendTag(res, uint32(k.Tags[ki]))
 		} else {
 			res = appendTag(res, 0)
 		}
@@ -212,10 +212,10 @@ func appendBadge(rng *rand.Rand, res []byte, k data_model.Key, v data_model.Item
 	// TODO - deprecated legacy badges and use new badges
 	switch k.Metric {
 	case format.BuiltinMetricIDIngestionStatus:
-		if k.Keys[1] == 0 {
+		if k.Tags[1] == 0 {
 			return res
 		}
-		switch k.Keys[2] {
+		switch k.Tags[2] {
 		case format.TagValueIDSrcIngestionStatusOKCached,
 			format.TagValueIDSrcIngestionStatusOKUncached:
 			return res
@@ -225,21 +225,21 @@ func appendBadge(rng *rand.Rand, res []byte, k data_model.Key, v data_model.Item
 			format.TagValueIDSrcIngestionStatusWarnMapTagSetTwice,
 			format.TagValueIDSrcIngestionStatusWarnOldCounterSemantic,
 			format.TagValueIDSrcIngestionStatusWarnMapInvalidRawTagValue:
-			return appendValueStat(rng, res, data_model.Key{Timestamp: ts, Metric: format.BuiltinMetricIDBadges, Keys: [16]int32{0, format.TagValueIDBadgeIngestionWarnings, k.Keys[1]}}, "", v, metricCache, usedTimestamps, newFormat)
+			return appendValueStat(rng, res, data_model.Key{Timestamp: ts, Metric: format.BuiltinMetricIDBadges, Tags: [16]int32{0, format.TagValueIDBadgeIngestionWarnings, k.Tags[1]}}, "", v, metricCache, usedTimestamps, newFormat)
 		}
-		return appendValueStat(rng, res, data_model.Key{Timestamp: ts, Metric: format.BuiltinMetricIDBadges, Keys: [16]int32{0, format.TagValueIDBadgeIngestionErrors, k.Keys[1]}}, "", v, metricCache, usedTimestamps, newFormat)
+		return appendValueStat(rng, res, data_model.Key{Timestamp: ts, Metric: format.BuiltinMetricIDBadges, Tags: [16]int32{0, format.TagValueIDBadgeIngestionErrors, k.Tags[1]}}, "", v, metricCache, usedTimestamps, newFormat)
 	case format.BuiltinMetricIDAgentSamplingFactor:
-		return appendValueStat(rng, res, data_model.Key{Timestamp: ts, Metric: format.BuiltinMetricIDBadges, Keys: [16]int32{0, format.TagValueIDBadgeAgentSamplingFactor, k.Keys[1]}}, "", v, metricCache, usedTimestamps, newFormat)
+		return appendValueStat(rng, res, data_model.Key{Timestamp: ts, Metric: format.BuiltinMetricIDBadges, Tags: [16]int32{0, format.TagValueIDBadgeAgentSamplingFactor, k.Tags[1]}}, "", v, metricCache, usedTimestamps, newFormat)
 	case format.BuiltinMetricIDAggSamplingFactor:
-		return appendValueStat(rng, res, data_model.Key{Timestamp: ts, Metric: format.BuiltinMetricIDBadges, Keys: [16]int32{0, format.TagValueIDBadgeAggSamplingFactor, k.Keys[4]}}, "", v, metricCache, usedTimestamps, newFormat)
+		return appendValueStat(rng, res, data_model.Key{Timestamp: ts, Metric: format.BuiltinMetricIDBadges, Tags: [16]int32{0, format.TagValueIDBadgeAggSamplingFactor, k.Tags[4]}}, "", v, metricCache, usedTimestamps, newFormat)
 	case format.BuiltinMetricIDAggMappingCreated:
-		if k.Keys[5] == format.TagValueIDAggMappingCreatedStatusOK ||
-			k.Keys[5] == format.TagValueIDAggMappingCreatedStatusCreated {
+		if k.Tags[5] == format.TagValueIDAggMappingCreatedStatusOK ||
+			k.Tags[5] == format.TagValueIDAggMappingCreatedStatusCreated {
 			return res
 		}
-		return appendValueStat(rng, res, data_model.Key{Timestamp: ts, Metric: format.BuiltinMetricIDBadges, Keys: [16]int32{0, format.TagValueIDBadgeAggMappingErrors, k.Keys[4]}}, "", v, metricCache, usedTimestamps, newFormat)
+		return appendValueStat(rng, res, data_model.Key{Timestamp: ts, Metric: format.BuiltinMetricIDBadges, Tags: [16]int32{0, format.TagValueIDBadgeAggMappingErrors, k.Tags[4]}}, "", v, metricCache, usedTimestamps, newFormat)
 	case format.BuiltinMetricIDAggBucketReceiveDelaySec:
-		return appendValueStat(rng, res, data_model.Key{Timestamp: ts, Metric: format.BuiltinMetricIDBadges, Keys: [16]int32{0, format.TagValueIDBadgeContributors, 0}}, "", v, metricCache, usedTimestamps, newFormat)
+		return appendValueStat(rng, res, data_model.Key{Timestamp: ts, Metric: format.BuiltinMetricIDBadges, Tags: [16]int32{0, format.TagValueIDBadgeContributors, 0}}, "", v, metricCache, usedTimestamps, newFormat)
 	}
 	return res
 }
@@ -524,10 +524,10 @@ func (a *Aggregator) RowDataMarshalAppendPositions(buckets []*aggregatorBucket, 
 						})
 						continue
 					}
-					if ingestionStatus && k.Keys[1] != 0 {
+					if ingestionStatus && k.Tags[1] != 0 {
 						// Ingestion status and other unlimited per-metric built-ins should use its metric budget
 						// So metrics are better isolated
-						accountMetric = k.Keys[1]
+						accountMetric = k.Tags[1]
 					}
 				}
 				sz := item.RowBinarySizeEstimate()
@@ -620,9 +620,9 @@ func (a *Aggregator) RowDataMarshalAppendPositions(buckets []*aggregatorBucket, 
 
 	insertTimeUnix := uint32(time.Now().Unix()) // same quality as timestamp from advanceBuckets, can be larger or smaller
 	for t := range usedTimestamps {
-		key := data_model.Key{Timestamp: insertTimeUnix, Metric: format.BuiltinMetricIDContributorsLog, Keys: [16]int32{0, int32(t)}}
+		key := data_model.Key{Timestamp: insertTimeUnix, Metric: format.BuiltinMetricIDContributorsLog, Tags: [16]int32{0, int32(t)}}
 		res = appendSimpleValueStat(rnd, res, key, float64(insertTimeUnix)-float64(t), 1, a.aggregatorHost, metricCache, nil, newFormat)
-		key = data_model.Key{Timestamp: t, Metric: format.BuiltinMetricIDContributorsLogRev, Keys: [16]int32{0, int32(insertTimeUnix)}}
+		key = data_model.Key{Timestamp: t, Metric: format.BuiltinMetricIDContributorsLogRev, Tags: [16]int32{0, int32(insertTimeUnix)}}
 		res = appendSimpleValueStat(rnd, res, key, float64(insertTimeUnix)-float64(t), 1, a.aggregatorHost, metricCache, nil, newFormat)
 	}
 	dur := time.Since(startTime)

--- a/internal/aggregator/aggregator_log.go
+++ b/internal/aggregator/aggregator_log.go
@@ -71,10 +71,10 @@ func (a *Aggregator) goInternalLog() {
 func (a *Aggregator) reportInsertKeys(bucketTime uint32, metric int32, historic bool, err error, status int, exception int) data_model.Key {
 	key := a.aggKey(bucketTime, metric, [16]int32{0, 0, 0, 0, format.TagValueIDConveyorRecent, format.TagValueIDInsertTimeOK, int32(status), int32(exception)})
 	if err != nil {
-		key.Keys[5] = format.TagValueIDInsertTimeError
+		key.Tags[5] = format.TagValueIDInsertTimeError
 	}
 	if historic {
-		key.Keys[4] = format.TagValueIDConveyorHistoric
+		key.Tags[4] = format.TagValueIDConveyorHistoric
 	}
 	return key
 }
@@ -82,10 +82,10 @@ func (a *Aggregator) reportInsertKeys(bucketTime uint32, metric int32, historic 
 func (a *Aggregator) reportExpInsertKeys(bucketTime uint32, metric int32, historic bool, err error, status int, exception int) data_model.Key {
 	key := a.aggKey(bucketTime, metric, [16]int32{0, 0, 0, 0, format.TagValueIDConveyorRecent, format.TagValueIDInsertTimeOK, int32(status), int32(exception), 1})
 	if err != nil {
-		key.Keys[5] = format.TagValueIDInsertTimeError
+		key.Tags[5] = format.TagValueIDInsertTimeError
 	}
 	if historic {
-		key.Keys[4] = format.TagValueIDConveyorHistoric
+		key.Tags[4] = format.TagValueIDConveyorHistoric
 	}
 	return key
 }

--- a/internal/aggregator/ingress_proxy.go
+++ b/internal/aggregator/ingress_proxy.go
@@ -151,7 +151,7 @@ func keyFromHctx(hctx *rpc.HandlerContext, resultTag int32) (data_model.Key, *fo
 	protocol := int32(hctx.ProtocolVersion())
 	return data_model.Key{
 		Metric: format.BuiltinMetricIDRPCRequests,
-		Keys:   [16]int32{0, format.TagValueIDComponentIngressProxy, int32(hctx.RequestTag()), resultTag, 0, 0, keyIDTag, 0, protocol},
+		Tags:   [16]int32{0, format.TagValueIDComponentIngressProxy, int32(hctx.RequestTag()), resultTag, 0, 0, keyIDTag, 0, protocol},
 	}, format.BuiltinMetricMetaRPCRequests
 }
 

--- a/internal/aggregator/ingress_proxy2.go
+++ b/internal/aggregator/ingress_proxy2.go
@@ -401,7 +401,7 @@ func (p *proxyConn) requestLoop(ctx context.Context, req proxyRequest) (_ proxyR
 	cryptoKeyID := p.clientConn.KeyID()
 	requestSize := data_model.Key{
 		Metric: format.BuiltinMetricIDRPCRequests,
-		Keys:   [16]int32{0, format.TagValueIDComponentIngressProxy, int32(req.RequestTag()), 0, 0, 0, int32(binary.BigEndian.Uint32(cryptoKeyID[:4])), 0, int32(p.clientConn.ProtocolVersion())},
+		Tags:   [16]int32{0, format.TagValueIDComponentIngressProxy, int32(req.RequestTag()), 0, 0, 0, int32(binary.BigEndian.Uint32(cryptoKeyID[:4])), 0, int32(p.clientConn.ProtocolVersion())},
 	}
 	for i := uint(0); ; i++ {
 		// request (tip) must be set except maybe graceful shutdown first iteration
@@ -450,7 +450,7 @@ func (p *proxyConn) requestLoop(ctx context.Context, req proxyRequest) (_ proxyR
 		if ctx.Err() != nil {
 			return req, nil // server shutdown
 		}
-		requestSize.Keys[2] = int32(req.RequestTag())
+		requestSize.Tags[2] = int32(req.RequestTag())
 	}
 }
 

--- a/internal/aggregator/simulator.go
+++ b/internal/aggregator/simulator.go
@@ -158,7 +158,7 @@ func RunSimulator(simID int, metricsStorage *metajournal.MetricsStorage, storage
 }
 
 func generateStats(simID int, journal *metajournal.MetricsStorage, s *agent.Agent, totalRange int, key1range int32, key2range int32, key3range int32) {
-	mag := s.CreateBuiltInItemValue(data_model.Key{Metric: 100, Keys: [16]int32{0, int32(simID)}}, journal.GetMetaMetric(100))
+	mag := s.CreateBuiltInItemValue(data_model.Key{Metric: 100, Tags: [16]int32{0, int32(simID)}}, journal.GetMetaMetric(100))
 
 	metricInfo1 := journal.GetMetaMetricByName(data_model.SimulatorMetricPrefix + "1")
 	metricInfo2 := journal.GetMetaMetricByName(data_model.SimulatorMetricPrefix + "2")
@@ -185,9 +185,9 @@ func generateStats(simID int, journal *metajournal.MetricsStorage, s *agent.Agen
 			kCounter1 := data_model.Key{
 				Metric: metricInfo1.MetricID,
 			}
-			kCounter1.Keys[1] = rng.Int31n(key1range)
-			kCounter1.Keys[2] = rng.Int31n(key2range)
-			kCounter1.Keys[3] = rng.Int31n(key3range)
+			kCounter1.Tags[1] = rng.Int31n(key1range)
+			kCounter1.Tags[2] = rng.Int31n(key2range)
+			kCounter1.Tags[3] = rng.Int31n(key3range)
 			cc := 1 + rng.Intn(4)
 			oneCounter += cc
 			s.AddCounterHost(kCounter1, float64(cc), 0, metricInfo1)
@@ -197,7 +197,7 @@ func generateStats(simID int, journal *metajournal.MetricsStorage, s *agent.Agen
 				kCounter1 := data_model.Key{
 					Metric: metricInfo1.MetricID,
 				}
-				kCounter1.Keys[4] = rng.Int31n(int32(totalRange))
+				kCounter1.Tags[4] = rng.Int31n(int32(totalRange))
 				cc := 1 + rng.Intn(4)
 				oneCounter += cc
 				s.AddCounterHost(kCounter1, float64(cc), 0, metricInfo1)
@@ -216,19 +216,19 @@ func generateStats(simID int, journal *metajournal.MetricsStorage, s *agent.Agen
 			kValue2 := data_model.Key{
 				Metric: metricInfo2.MetricID,
 			}
-			kValue2.Keys[1] = rng.Int31n(key1range)
-			kValue2.Keys[2] = rng.Int31n(key2range)
-			kValue2.Keys[3] = rng.Int31n(key3range)
+			kValue2.Tags[1] = rng.Int31n(key1range)
+			kValue2.Tags[2] = rng.Int31n(key2range)
+			kValue2.Tags[3] = rng.Int31n(key3range)
 			kValue3 := kValue2
 			kValue3.Metric = metricInfo3.MetricID
 			kValue10 := data_model.Key{
 				Metric: metricInfo10.MetricID,
 			}
-			kValue10.Keys[1] = kValue2.Keys[1]
-			kValue10.Keys[2] = kValue2.Keys[2]
+			kValue10.Tags[1] = kValue2.Tags[1]
+			kValue10.Tags[2] = kValue2.Tags[2]
 			kValue11 := kValue10
 			kValue11.Metric = metricInfo11.MetricID
-			sKey := stop[int(kValue2.Keys[3])%len(stop)]
+			sKey := stop[int(kValue2.Tags[3])%len(stop)]
 			cc := 1 + rng.Intn(4)
 			for ci := 0; ci < cc; ci++ {
 				value := rng.Float64() * 100
@@ -244,17 +244,17 @@ func generateStats(simID int, journal *metajournal.MetricsStorage, s *agent.Agen
 			kUnique4 := data_model.Key{
 				Metric: metricInfo4.MetricID,
 			}
-			kUnique4.Keys[1] = rng.Int31n(key1range)
-			kUnique4.Keys[2] = rng.Int31n(key2range)
-			kUnique4.Keys[3] = rng.Int31n(key3range)
+			kUnique4.Tags[1] = rng.Int31n(key1range)
+			kUnique4.Tags[2] = rng.Int31n(key2range)
+			kUnique4.Tags[3] = rng.Int31n(key3range)
 			kUnique7 := kUnique4
 			kUnique7.Metric = metricInfo7.MetricID
 			kUnique8 := data_model.Key{
 				Metric: metricInfo8.MetricID,
 			}
-			kUnique8.Keys[1] = kUnique4.Keys[1]
-			kUnique8.Keys[2] = kUnique4.Keys[2]
-			sKey := stop[int(kUnique4.Keys[3])%len(stop)]
+			kUnique8.Tags[1] = kUnique4.Tags[1]
+			kUnique8.Tags[2] = kUnique4.Tags[2]
+			sKey := stop[int(kUnique4.Tags[3])%len(stop)]
 			cc := 1 + rng.Intn(4)
 			for ci := 0; ci < cc; ci++ {
 				const D = 1000000
@@ -271,7 +271,7 @@ func generateStats(simID int, journal *metajournal.MetricsStorage, s *agent.Agen
 			kValue5 := data_model.Key{
 				Metric: metricInfo5.MetricID,
 			}
-			kValue5.Keys[2] = rng.Int31n(key2range)
+			kValue5.Tags[2] = rng.Int31n(key2range)
 			sid := rng.Intn(len(stop) * 100)
 			if sid < len(stop) {
 				s.AddCounterHostStringBytes(kValue5, stop[sid], 1, 0, metricInfo5)
@@ -286,10 +286,10 @@ func generateStats(simID int, journal *metajournal.MetricsStorage, s *agent.Agen
 			kCounter6 := data_model.Key{
 				Metric: metricInfo6.MetricID,
 			}
-			kCounter6.Keys[1] = rng.Int31n(key1range)
-			kCounter6.Keys[2] = rng.Int31n(key2range)
-			kCounter6.Keys[3] = rng.Int31n(key3range)
-			kCounter6.Keys[4] = rng.Int31n(1000)
+			kCounter6.Tags[1] = rng.Int31n(key1range)
+			kCounter6.Tags[2] = rng.Int31n(key2range)
+			kCounter6.Tags[3] = rng.Int31n(key3range)
+			kCounter6.Tags[4] = rng.Int31n(1000)
 			s.AddCounterHost(kCounter6, 1, 0, metricInfo6)
 		}
 

--- a/internal/aggregator/tags_mapper.go
+++ b/internal/aggregator/tags_mapper.go
@@ -156,7 +156,7 @@ func (ms *TagsMapper) mapOrFlood(now time.Time, value []byte, metricName string,
 // safe only to access fields mask in args, other fields point to reused memory
 func (ms *TagsMapper) sendCreateTagMappingResult(hctx *rpc.HandlerContext, args tlstatshouse.GetTagMapping2Bytes, r pcache.Result, key data_model.Key, meta *format.MetricMetaValue) (err error) {
 	if r.Err != nil {
-		key.Keys[5] = format.TagValueIDAggMappingStatusErrUncached
+		key.Tags[5] = format.TagValueIDAggMappingStatusErrUncached
 		ms.sh2.AddCounter(key, 1, meta)
 		return r.Err
 	}
@@ -207,7 +207,7 @@ func (ms *TagsMapper) handleCreateTagMapping(_ context.Context, hctx *rpc.Handle
 			ms.mu.Lock()
 			defer ms.mu.Unlock()
 			if *bb {
-				key.Keys[5] = format.TagValueIDAggMappingStatusOKUncached
+				key.Tags[5] = format.TagValueIDAggMappingStatusOKUncached
 				err := ms.sendCreateTagMappingResult(hctx, args, v, key, meta)
 				hctx.SendHijackedResponse(err)
 			}

--- a/internal/data_model/bucket.go
+++ b/internal/data_model/bucket.go
@@ -9,7 +9,6 @@ package data_model
 import (
 	"encoding/binary"
 	"sort"
-	"unsafe"
 
 	"pgregory.net/rand"
 
@@ -96,11 +95,6 @@ func (k *Key) ClearedKeys() Key {
 }
 
 func (k *Key) Hash() uint64 {
-	a := (*[unsafe.Sizeof(*k)]byte)(unsafe.Pointer(k))
-	return siphash.Hash(sipKeyA, sipKeyB, a[4:]) // timestamp is not part of shard
-}
-
-func (k *Key) HashSafe() uint64 {
 	var b [4 + 4*format.MaxTags]byte
 	// timestamp is not part of shard
 	binary.LittleEndian.PutUint32(b[:], uint32(k.Metric))

--- a/internal/data_model/bucket.go
+++ b/internal/data_model/bucket.go
@@ -26,7 +26,7 @@ type (
 	Key struct {
 		Timestamp uint32
 		Metric    int32
-		Keys      [format.MaxTags]int32 // Unused keys are set to special 0-value
+		Tags      [format.MaxTags]int32 // Unused tags are set to special 0-value
 	}
 
 	ItemCounter struct {
@@ -75,19 +75,19 @@ func (s *ItemCounter) Count() float64 { return s.counter }
 func (k Key) WithAgentEnvRouteArch(agentEnvTag int32, routeTag int32, buildArchTag int32) Key {
 	// when aggregator receives metric from an agent inside another aggregator, those keys are already set,
 	// so we simply keep them. AgentEnvTag or RouteTag are always non-zero in this case.
-	if k.Keys[format.AgentEnvTag] == 0 {
-		k.Keys[format.AgentEnvTag] = agentEnvTag
-		k.Keys[format.RouteTag] = routeTag
-		k.Keys[format.BuildArchTag] = buildArchTag
+	if k.Tags[format.AgentEnvTag] == 0 {
+		k.Tags[format.AgentEnvTag] = agentEnvTag
+		k.Tags[format.RouteTag] = routeTag
+		k.Tags[format.BuildArchTag] = buildArchTag
 	}
 	return k
 }
 
 func AggKey(t uint32, m int32, k [format.MaxTags]int32, hostTagId int32, shardTag int32, replicaTag int32) Key {
-	key := Key{Timestamp: t, Metric: m, Keys: k}
-	key.Keys[format.AggHostTag] = hostTagId
-	key.Keys[format.AggShardTag] = shardTag
-	key.Keys[format.AggReplicaTag] = replicaTag
+	key := Key{Timestamp: t, Metric: m, Tags: k}
+	key.Tags[format.AggHostTag] = hostTagId
+	key.Tags[format.AggShardTag] = shardTag
+	key.Tags[format.AggReplicaTag] = replicaTag
 	return key
 }
 
@@ -104,22 +104,22 @@ func (k *Key) HashSafe() uint64 {
 	var b [4 + 4*format.MaxTags]byte
 	// timestamp is not part of shard
 	binary.LittleEndian.PutUint32(b[:], uint32(k.Metric))
-	binary.LittleEndian.PutUint32(b[4+0*4:], uint32(k.Keys[0]))
-	binary.LittleEndian.PutUint32(b[4+1*4:], uint32(k.Keys[1]))
-	binary.LittleEndian.PutUint32(b[4+2*4:], uint32(k.Keys[2]))
-	binary.LittleEndian.PutUint32(b[4+3*4:], uint32(k.Keys[3]))
-	binary.LittleEndian.PutUint32(b[4+4*4:], uint32(k.Keys[4]))
-	binary.LittleEndian.PutUint32(b[4+5*4:], uint32(k.Keys[5]))
-	binary.LittleEndian.PutUint32(b[4+6*4:], uint32(k.Keys[6]))
-	binary.LittleEndian.PutUint32(b[4+7*4:], uint32(k.Keys[7]))
-	binary.LittleEndian.PutUint32(b[4+8*4:], uint32(k.Keys[8]))
-	binary.LittleEndian.PutUint32(b[4+9*4:], uint32(k.Keys[9]))
-	binary.LittleEndian.PutUint32(b[4+10*4:], uint32(k.Keys[10]))
-	binary.LittleEndian.PutUint32(b[4+11*4:], uint32(k.Keys[11]))
-	binary.LittleEndian.PutUint32(b[4+12*4:], uint32(k.Keys[12]))
-	binary.LittleEndian.PutUint32(b[4+13*4:], uint32(k.Keys[13]))
-	binary.LittleEndian.PutUint32(b[4+14*4:], uint32(k.Keys[14]))
-	binary.LittleEndian.PutUint32(b[4+15*4:], uint32(k.Keys[15]))
+	binary.LittleEndian.PutUint32(b[4+0*4:], uint32(k.Tags[0]))
+	binary.LittleEndian.PutUint32(b[4+1*4:], uint32(k.Tags[1]))
+	binary.LittleEndian.PutUint32(b[4+2*4:], uint32(k.Tags[2]))
+	binary.LittleEndian.PutUint32(b[4+3*4:], uint32(k.Tags[3]))
+	binary.LittleEndian.PutUint32(b[4+4*4:], uint32(k.Tags[4]))
+	binary.LittleEndian.PutUint32(b[4+5*4:], uint32(k.Tags[5]))
+	binary.LittleEndian.PutUint32(b[4+6*4:], uint32(k.Tags[6]))
+	binary.LittleEndian.PutUint32(b[4+7*4:], uint32(k.Tags[7]))
+	binary.LittleEndian.PutUint32(b[4+8*4:], uint32(k.Tags[8]))
+	binary.LittleEndian.PutUint32(b[4+9*4:], uint32(k.Tags[9]))
+	binary.LittleEndian.PutUint32(b[4+10*4:], uint32(k.Tags[10]))
+	binary.LittleEndian.PutUint32(b[4+11*4:], uint32(k.Tags[11]))
+	binary.LittleEndian.PutUint32(b[4+12*4:], uint32(k.Tags[12]))
+	binary.LittleEndian.PutUint32(b[4+13*4:], uint32(k.Tags[13]))
+	binary.LittleEndian.PutUint32(b[4+14*4:], uint32(k.Tags[14]))
+	binary.LittleEndian.PutUint32(b[4+15*4:], uint32(k.Tags[15]))
 	const _ = uint(16 - format.MaxTags) // compile time assert to manually add new keys above
 	return siphash.Hash(sipKeyA, sipKeyB, b[:])
 }

--- a/internal/data_model/bucket.go
+++ b/internal/data_model/bucket.go
@@ -90,10 +90,6 @@ func AggKey(t uint32, m int32, k [format.MaxTags]int32, hostTagId int32, shardTa
 	return key
 }
 
-func (k *Key) ClearedKeys() Key {
-	return Key{Timestamp: k.Timestamp, Metric: k.Metric}
-}
-
 func (k *Key) Hash() uint64 {
 	var b [4 + 4*format.MaxTags]byte
 	// timestamp is not part of shard

--- a/internal/data_model/mapped_metric_header.go
+++ b/internal/data_model/mapped_metric_header.go
@@ -60,7 +60,7 @@ func (h *MappedMetricHeader) SetKey(index int, id int32, tagIDKey int32) {
 		}
 		h.IsHKeySet = true
 	} else {
-		h.Key.Keys[index] = id
+		h.Key.Tags[index] = id
 		if h.IsKeySet[index] {
 			h.TagSetTwiceKey = tagIDKey
 		}

--- a/internal/data_model/mapped_metric_header.go
+++ b/internal/data_model/mapped_metric_header.go
@@ -24,7 +24,7 @@ type MapCallbackFunc func(tlstatshouse.MetricBytes, MappedMetricHeader)
 
 type MappedMetricHeader struct {
 	ReceiveTime time.Time // Saved at mapping start and used where we need time.Now. This is different to MetricBatch.T, which is sent by clients
-	MetricInfo  *format.MetricMetaValue
+	MetricMeta  *format.MetricMetaValue
 	Key         Key
 	SValue      []byte // reference to memory inside tlstatshouse.MetricBytes.
 	HostTag     int32

--- a/internal/data_model/sampling.go
+++ b/internal/data_model/sampling.go
@@ -161,8 +161,8 @@ func (h *sampler) Run(budget int64) {
 				n = maxFairKeyLen
 			}
 			for j := 0; j < n; j++ {
-				if x := h.items[i].metric.FairKey[j]; 0 <= x && x < len(h.items[i].Key.Keys) {
-					h.items[i].fairKey[j] = h.items[i].Key.Keys[x]
+				if x := h.items[i].metric.FairKey[j]; 0 <= x && x < len(h.items[i].Key.Tags) {
+					h.items[i].fairKey[j] = h.items[i].Key.Tags[x]
 				}
 			}
 			h.items[i].fairKeyLen = n

--- a/internal/data_model/sampling_test.go
+++ b/internal/data_model/sampling_test.go
@@ -215,9 +215,9 @@ func TestFairKeySampling(t *testing.T) {
 		m := Key{Metric: 1}
 		n := rapid.IntRange(1, 16).Draw(t, "fair key value count")
 		for i, v := 1, 1; i <= n; i, v = i+1, v*2 {
-			m.Keys[0] = int32(i)
+			m.Tags[0] = int32(i)
 			for j := 1; j <= v; j++ {
-				m.Keys[1] = int32(j)
+				m.Tags[1] = int32(j)
 				v := &MultiItem{}
 				v.Tail.Value.AddValueCounter(0, 1)
 				b.series[m] = v
@@ -415,7 +415,7 @@ func (b *samplingTestBucket) generateSeriesCount(t *rapid.T, s samplingTestSpec)
 		)
 		for i := 0; i < seriesCount; i++ {
 			var (
-				k = Key{Metric: metricID, Keys: [format.MaxTags]int32{int32(i + 1)}}
+				k = Key{Metric: metricID, Tags: [format.MaxTags]int32{int32(i + 1)}}
 				v = &MultiItem{}
 			)
 			v.Tail.Value.AddValueCounter(0, 1)
@@ -442,7 +442,7 @@ func (b *samplingTestBucket) generateSeriesSize(t *rapid.T, s samplingTestSpec) 
 		)
 		for i := int32(1); size < sizeT; i++ {
 			var (
-				k = Key{Metric: metricID, Keys: [format.MaxTags]int32{i}}
+				k = Key{Metric: metricID, Tags: [format.MaxTags]int32{i}}
 				v = &MultiItem{}
 			)
 			v.Tail.Value.AddValueCounter(0, 1)
@@ -538,7 +538,7 @@ func benchmarkSampleBucket(b *testing.B, f func(*MetricsBucket, samplerConfigEx)
 		metricID := int32(i + 1)
 		for i := 0; i < seriesCount; i++ {
 			var (
-				k = Key{Metric: metricID, Keys: [format.MaxTags]int32{int32(i + 1)}}
+				k = Key{Metric: metricID, Tags: [format.MaxTags]int32{int32(i + 1)}}
 				v = &MultiItem{}
 			)
 			v.Tail.Value.AddValueCounter(0, 1)
@@ -558,13 +558,13 @@ func sampleBucket(bucket *MetricsBucket, config samplerConfigEx) []tlstatshouse.
 		accountMetric := k.Metric
 		sz := k.TLSizeEstimate(bucket.Time) + item.TLSizeEstimate()
 		if k.Metric == format.BuiltinMetricIDIngestionStatus {
-			if k.Keys[1] != 0 {
+			if k.Tags[1] != 0 {
 				// Ingestion status and other unlimited per-metric built-ins should use its metric budget
 				// So metrics are better isolated
-				accountMetric = k.Keys[1]
+				accountMetric = k.Tags[1]
 				whaleWeight = 0 // ingestion statuses do not compete for whale status
 			}
-			if k.Keys[2] == format.TagValueIDSrcIngestionStatusOKCached {
+			if k.Tags[2] == format.TagValueIDSrcIngestionStatusOKCached {
 				// These are so common, we have transfer optimization for them
 				sz = 3 * 4 // see statshouse.ingestion_status2
 			}
@@ -595,13 +595,13 @@ func sampleBucketLegacy(bucket *MetricsBucket, config samplerConfigEx) []tlstats
 		accountMetric := k.Metric
 		sz := k.TLSizeEstimate(bucket.Time) + item.TLSizeEstimate()
 		if k.Metric == format.BuiltinMetricIDIngestionStatus {
-			if k.Keys[1] != 0 {
+			if k.Tags[1] != 0 {
 				// Ingestion status and other unlimited per-metric built-ins should use its metric budget
 				// So metrics are better isolated
-				accountMetric = k.Keys[1]
+				accountMetric = k.Tags[1]
 				whaleWeight = 0 // ingestion statuses do not compete for whale status
 			}
-			if k.Keys[2] == format.TagValueIDSrcIngestionStatusOKCached {
+			if k.Tags[2] == format.TagValueIDSrcIngestionStatusOKCached {
 				// These are so common, we have transfer optimization for them
 				sz = 3 * 4 // see statshouse.ingestion_status2
 			}

--- a/internal/data_model/transfer.go
+++ b/internal/data_model/transfer.go
@@ -18,7 +18,7 @@ import (
 )
 
 func (k *Key) ToSlice() []int32 {
-	result := append([]int32{}, k.Keys[:]...)
+	result := append([]int32{}, k.Tags[:]...)
 	i := format.MaxTags
 	for ; i != 0; i-- {
 		if result[i-1] != 0 {
@@ -45,14 +45,14 @@ func KeyFromStatshouseMultiItem(item *tlstatshouse.MultiItemBytes, bucketTimesta
 		// above checks can be moved below }, but they will always be NOP as bucketTimestamp is both <= newestTime and in beleive window
 	}
 	key.Metric = item.Metric
-	copy(key.Keys[:], item.Keys)
+	copy(key.Tags[:], item.Keys)
 	return key, int(sID)
 }
 
 func (k *Key) TLSizeEstimate(defaultTimestamp uint32) int {
 	i := format.MaxTags
 	for ; i != 0; i-- {
-		if k.Keys[i-1] != 0 {
+		if k.Tags[i-1] != 0 {
 			break
 		}
 	}

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -22,6 +22,7 @@ import (
 	"go4.org/mem"
 
 	"github.com/mailru/easyjson/opt"
+
 	"github.com/vkcom/statshouse-go"
 )
 
@@ -156,6 +157,7 @@ type MetricMetaTag struct {
 	RawKind       string            `json:"raw_kind,omitempty"` // UI can show some raw values beautifully - timestamps, hex values, etc.
 	ID2Value      map[int32]string  `json:"id2value,omitempty"`
 	ValueComments map[string]string `json:"value_comments,omitempty"`
+	SkipMapping   bool              `json:"skip_mapping,omitempty"` // used only in v3 conveer
 
 	Comment2Value map[string]string `json:"-"` // Should be restored from ValueComments after reading
 	IsMetric      bool              `json:"-"` // Only for built-in metrics so never saved or parsed

--- a/internal/mapping/autocreate.go
+++ b/internal/mapping/autocreate.go
@@ -65,7 +65,7 @@ func (ac *AutoCreate) Shutdown() {
 	ac.shutdownFn()
 }
 
-func (ac *AutoCreate) autoCreateMetric(bytes *tlstatshouse.MetricBytes, description string, resolution int, now time.Time) error {
+func (ac *AutoCreate) AutoCreateMetric(bytes *tlstatshouse.MetricBytes, description string, resolution int, now time.Time) error {
 	ac.mu.RLock()
 	task := ac.work[string(bytes.Name)]
 	taskCount := len(ac.work)
@@ -90,7 +90,7 @@ func (ac *AutoCreate) autoCreateMetric(bytes *tlstatshouse.MetricBytes, descript
 	return nil
 }
 
-func (ac *AutoCreate) autoCreateTag(bytes *tlstatshouse.MetricBytes, tagBytes []byte, now time.Time) error {
+func (ac *AutoCreate) AutoCreateTag(bytes *tlstatshouse.MetricBytes, tagBytes []byte, now time.Time) error {
 	ac.mu.RLock()
 	task := ac.work[string(bytes.Name)]
 	done := false

--- a/internal/mapping/mapper.go
+++ b/internal/mapping/mapper.go
@@ -58,6 +58,6 @@ func (m *Mapper) Stop() {
 }
 
 // cb.MetricInfo must be set from journal. If nil, will lookup allowed built-in metric, otherwise set ingestion status not found
-func (m *Mapper) Map(args data_model.HandlerArgs, metricInfo *format.MetricMetaValue) (data_model.MappedMetricHeader, bool) {
-	return m.pipeline.Map(args, metricInfo)
+func (m *Mapper) Map(args data_model.HandlerArgs, metricInfo *format.MetricMetaValue, h *data_model.MappedMetricHeader) (done bool) {
+	return m.pipeline.Map(args, metricInfo, h)
 }

--- a/internal/mapping/mapper.go
+++ b/internal/mapping/mapper.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/vkcom/statshouse/internal/data_model"
+	"github.com/vkcom/statshouse/internal/data_model/gen2/tlstatshouse"
 	"github.com/vkcom/statshouse/internal/format"
 	"github.com/vkcom/statshouse/internal/pcache"
 )
@@ -60,4 +61,10 @@ func (m *Mapper) Stop() {
 // cb.MetricInfo must be set from journal. If nil, will lookup allowed built-in metric, otherwise set ingestion status not found
 func (m *Mapper) Map(args data_model.HandlerArgs, metricInfo *format.MetricMetaValue, h *data_model.MappedMetricHeader) (done bool) {
 	return m.pipeline.Map(args, metricInfo, h)
+}
+
+// We wish to know which environment generates 'metric not found' events and other errors
+// so we call it even if we had an error
+func (m *Mapper) MapEnvironment(metric *tlstatshouse.MetricBytes, h *data_model.MappedMetricHeader) {
+	m.pipeline.MapEnvironment(metric, h)
 }

--- a/internal/mapping/pipeline.go
+++ b/internal/mapping/pipeline.go
@@ -125,7 +125,7 @@ func (mp *mapPipeline) mapTags(h *data_model.MappedMetricHeader, metric *tlstats
 				extra := format.CreateMappingExtra{ // Host and AgentEnv are added by source when sending
 					Metric:    string(metric.Name),
 					TagIDKey:  tagIDKey,
-					ClientEnv: h.Key.Keys[0], // mapEnvironment sets this, but only if already in cache, which is normally almost always.
+					ClientEnv: h.Key.Tags[0], // mapEnvironment sets this, but only if already in cache, which is normally almost always.
 				}
 				id, err := mp.getTagValueID(h.ReceiveTime, v.Value, extra)
 				if err != nil {
@@ -208,7 +208,7 @@ func (mp *mapPipeline) MapEnvironment(metric *tlstatshouse.MetricBytes, h *data_
 		if err != nil || !found {
 			return // do not bother if the first one set is crappy
 		}
-		h.Key.Keys[0] = id
+		h.Key.Tags[0] = id
 		return // we are ok with the first one
 	}
 }
@@ -247,7 +247,7 @@ func MapErrorFromHeader(m tlstatshouse.MetricBytes, h data_model.MappedMetricHea
 		return nil
 	}
 	ingestionTagName := format.TagIDTagToTagID(h.IngestionTagKey)
-	envTag := h.Key.Keys[0] // TODO - we do not want to remember original string value somewhere yet (to print better errors here)
+	envTag := h.Key.Tags[0] // TODO - we do not want to remember original string value somewhere yet (to print better errors here)
 	switch h.IngestionStatus {
 	case format.TagValueIDSrcIngestionStatusErrMetricNotFound:
 		return fmt.Errorf("metric %q not found (envTag %d)", m.Name, envTag)

--- a/internal/mapping/pipeline.go
+++ b/internal/mapping/pipeline.go
@@ -69,7 +69,7 @@ func (mp *mapPipeline) mapTags(h *data_model.MappedMetricHeader, metric *tlstats
 	// We do not validate metric name or tag keys, because they will be searched in finite maps
 	for ; h.CheckedTagIndex < len(metric.Tags); h.CheckedTagIndex++ {
 		v := &metric.Tags[h.CheckedTagIndex]
-		tagInfo, ok, legacyName := h.MetricInfo.APICompatGetTagFromBytes(v.Key)
+		tagInfo, ok, legacyName := h.MetricMeta.APICompatGetTagFromBytes(v.Key)
 		if !ok {
 			validKey, err := format.AppendValidStringValue(v.Key[:0], v.Key)
 			if err != nil {
@@ -79,7 +79,7 @@ func (mp *mapPipeline) mapTags(h *data_model.MappedMetricHeader, metric *tlstats
 				return true
 			}
 			v.Key = validKey
-			if _, ok := h.MetricInfo.GetTagDraft(v.Key); ok {
+			if _, ok := h.MetricMeta.GetTagDraft(v.Key); ok {
 				h.FoundDraftTagName = v.Key
 			} else {
 				h.NotFoundTagName = v.Key

--- a/internal/mapping/pipeline.go
+++ b/internal/mapping/pipeline.go
@@ -40,13 +40,6 @@ func (mp *mapPipeline) stop() {
 }
 
 func (mp *mapPipeline) Map(args data_model.HandlerArgs, metricInfo *format.MetricMetaValue, h *data_model.MappedMetricHeader) (done bool) {
-	// We do not check fields mask in code below, only field value, because
-	// sending 0 instead of manipulating field mask is more convenient for many clients
-	if args.MetricBytes.Ts != 0 {
-		h.Key.Timestamp = args.MetricBytes.Ts
-	} else { // we encourage users to mark events with explicit timestamp, so this branch must be rare
-		h.Key.Timestamp = uint32(h.ReceiveTime.Unix())
-	}
 	done = mp.doMap(args, h)
 	// We map environment in all 3 cases
 	// done and no errors - very fast NOP
@@ -57,11 +50,6 @@ func (mp *mapPipeline) Map(args data_model.HandlerArgs, metricInfo *format.Metri
 }
 
 func (mp *mapPipeline) doMap(args data_model.HandlerArgs, h *data_model.MappedMetricHeader) (done bool) {
-	h.Key.Metric = h.MetricInfo.MetricID
-	if !h.MetricInfo.Visible {
-		h.IngestionStatus = format.TagValueIDSrcIngestionStatusErrMetricInvisible
-		return true
-	}
 	metric := args.MetricBytes
 	if done = mp.mapTags(h, metric, true); done {
 		return done

--- a/internal/receiver/receiver.go
+++ b/internal/receiver/receiver.go
@@ -145,7 +145,7 @@ func createBatchSizeValue(ag *agent.Agent, formatTagValueID int32, statusTagValu
 	if ag != nil {
 		return ag.CreateBuiltInItemValue(data_model.Key{
 			Metric: format.BuiltinMetricIDAgentReceivedBatchSize,
-			Keys:   [format.MaxTags]int32{0 /* env */, formatTagValueID, statusTagValueID, protocolTagValueID},
+			Tags:   [format.MaxTags]int32{0 /* env */, formatTagValueID, statusTagValueID, protocolTagValueID},
 		}, format.BuiltinMetricMetaAgentReceivedBatchSize)
 	}
 	return nil
@@ -155,7 +155,7 @@ func createPacketSizeValue(bm *agent.Agent, formatTagValueID int32, statusTagVal
 	if bm != nil {
 		return bm.CreateBuiltInItemValue(data_model.Key{
 			Metric: format.BuiltinMetricIDAgentReceivedPacketSize,
-			Keys:   [format.MaxTags]int32{0 /* env */, formatTagValueID, statusTagValueID, protocolTagValueID},
+			Tags:   [format.MaxTags]int32{0 /* env */, formatTagValueID, statusTagValueID, protocolTagValueID},
 		}, format.BuiltinMetricMetaAgentReceivedPacketSize)
 	}
 	return nil

--- a/internal/sharding/sharding.go
+++ b/internal/sharding/sharding.go
@@ -50,7 +50,7 @@ func shardByMappedTags(keyHash uint64, numShards int) uint32 {
 }
 
 func shardByTag(key data_model.Key, tagId uint32, numShards int) uint32 {
-	return uint32(key.Keys[tagId]) % uint32(numShards)
+	return uint32(key.Tags[tagId]) % uint32(numShards)
 }
 
 func shardByMetricId(key data_model.Key, numShards int) uint32 {

--- a/internal/sharding/sharding_test.go
+++ b/internal/sharding/sharding_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 func TestShard(t *testing.T) {
-	metric1 := data_model.Key{Timestamp: 1000, Metric: 1, Keys: [format.MaxTags]int32{1, 2, 3}}
-	metric2 := data_model.Key{Timestamp: 1000, Metric: 2, Keys: [format.MaxTags]int32{5, 6}}
+	metric1 := data_model.Key{Timestamp: 1000, Metric: 1, Tags: [format.MaxTags]int32{1, 2, 3}}
+	metric2 := data_model.Key{Timestamp: 1000, Metric: 2, Tags: [format.MaxTags]int32{5, 6}}
 	metricBuiltin := data_model.Key{Timestamp: 1000, Metric: -1000}
 	pastTs := uint32(900)
 	futureTs := uint32(1100)


### PR DESCRIPTION
- abolish unsafe Hash, always use safe variant
- `MetricInfo` -> `MetricMeta`
- `Key.Keys` -> `Key.Tags`
- extract stuff that has nothing to do with tags or mapping from mapping pipeline