### PR TITLE
Use pointer to Key instead of value

### DIFF
--- a/cmd/statshouse/shutdown_info.go
+++ b/cmd/statshouse/shutdown_info.go
@@ -29,53 +29,53 @@ func shutdownInfoReport(sh2 *agent.Agent, componentTag int32, storageDir string,
 	finishShutdownTime := time.Unix(0, si.FinishShutdownTime)
 	if dur := globalStartTime.Sub(finishShutdownTime); si.FinishShutdownTime > 0 && dur > 0 && dur < time.Hour {
 		// arbitrary check that if start took more than 1 hour, this was not restart, and we do not want such case in our averages
-		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
+		sh2.AddValueCounter(&data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
 			Tags: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseInactive}},
 			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	if dur := time.Duration(si.StopRecentSenders); dur > 0 {
-		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
+		sh2.AddValueCounter(&data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
 			Tags: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopRecentSenders}},
 			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	if dur := time.Duration(si.StopReceivers); dur > 0 {
-		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
+		sh2.AddValueCounter(&data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
 			Tags: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopReceivers}},
 			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	if dur := time.Duration(si.StopFlusher); dur > 0 {
-		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
+		sh2.AddValueCounter(&data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
 			Tags: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopFlusher}},
 			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	if dur := time.Duration(si.StopFlushing); dur > 0 {
-		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
+		sh2.AddValueCounter(&data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
 			Tags: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopFlushing}},
 			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	if dur := time.Duration(si.StopPreprocessor); dur > 0 {
-		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
+		sh2.AddValueCounter(&data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
 			Tags: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopPreprocessor}},
 			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	if dur := time.Duration(si.StopInserters); dur > 0 {
-		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
+		sh2.AddValueCounter(&data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
 			Tags: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopInserters}},
 			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	if dur := time.Duration(si.StopRPCServer); dur > 0 {
-		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
+		sh2.AddValueCounter(&data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
 			Tags: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStopRPCServer}},
 			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	finishLoadingTime := time.Now()
 	if dur := startDiscCache.Sub(globalStartTime); dur > 0 {
-		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
+		sh2.AddValueCounter(&data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
 			Tags: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStartDiskCache}},
 			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
 	if dur := finishLoadingTime.Sub(startDiscCache); dur > 0 {
-		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
+		sh2.AddValueCounter(&data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
 			Tags: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseStartService}},
 			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 	}
@@ -83,7 +83,7 @@ func shutdownInfoReport(sh2 *agent.Agent, componentTag int32, storageDir string,
 	startShutdownTime := time.Unix(0, si.StartShutdownTime)
 	if dur := finishLoadingTime.Sub(startShutdownTime); si.StartShutdownTime > 0 && dur > 0 && dur < time.Hour {
 		// arbitrary check that if start took more than 1 hour, this was not restart, and we do not want such case in our averages
-		sh2.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
+		sh2.AddValueCounter(&data_model.Key{Metric: format.BuiltinMetricIDRestartTimings,
 			Tags: [16]int32{0, componentTag, format.TagValueIDRestartTimingsPhaseTotal}},
 			dur.Seconds(), 1, format.BuiltinMetricMetaRestartTimings)
 		logOk.Printf("restart finished in %v (since shutdown start time recorded by previous instance)", dur)

--- a/cmd/statshouse/statshouse.go
+++ b/cmd/statshouse/statshouse.go
@@ -290,12 +290,12 @@ func mainAgent(aesPwd string, dc *pcache.DiskCache) int {
 			}
 			for _, r := range receiversUDP {
 				v := float64(r.ReceiveBufferSize())
-				a.AddValueCounter(k, v, 1, format.BuiltinMetricMetaAgentUDPReceiveBufferSize)
+				a.AddValueCounter(&k, v, 1, format.BuiltinMetricMetaAgentUDPReceiveBufferSize)
 			}
 			if dc != nil {
 				s, err := dc.DiskSizeBytes()
 				if err == nil {
-					a.AddValueCounter(data_model.Key{Timestamp: unixNow, Metric: format.BuiltinMetricIDAgentDiskCacheSize, Tags: [16]int32{0, 0, 0}}, float64(s), 1, format.BuiltinMetricMetaAgentDiskCacheSize)
+					a.AddValueCounter(&data_model.Key{Timestamp: unixNow, Metric: format.BuiltinMetricIDAgentDiskCacheSize, Tags: [16]int32{0, 0, 0}}, float64(s), 1, format.BuiltinMetricMetaAgentDiskCacheSize)
 				}
 			}
 		},

--- a/internal/agent/agent_loaders.go
+++ b/internal/agent/agent_loaders.go
@@ -173,7 +173,7 @@ func (s *Agent) LoadMetaMetricJournal(ctxParent context.Context, version int64, 
 	// On the other hand, if aggregators cannot map, but can insert, system is working
 	// So, we must have separate live-dead status for mappings - TODO
 	if s0 == nil {
-		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Tags: [format.MaxTags]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusAllDead}}, 0, 1, format.BuiltinMetricMetaAgentMapping)
+		s.AddValueCounter(&data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Tags: [format.MaxTags]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusAllDead}}, 0, 1, format.BuiltinMetricMetaAgentMapping)
 		return nil, version, fmt.Errorf("cannot load meta journal, all aggregators are dead")
 	}
 	now := time.Now()
@@ -189,7 +189,7 @@ func (s *Agent) LoadMetaMetricJournal(ctxParent context.Context, version int64, 
 	// We do not need timeout for long poll, RPC has disconnect detection via ping-pong
 	err := s0.client.GetMetrics3(ctxParent, args, &extra, &ret)
 	if err != nil {
-		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Tags: [format.MaxTags]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusErrSingle}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
+		s.AddValueCounter(&data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Tags: [format.MaxTags]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusErrSingle}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
 		return nil, version, fmt.Errorf("cannot load meta journal - %w", err)
 	}
 	/*
@@ -197,7 +197,7 @@ func (s *Agent) LoadMetaMetricJournal(ctxParent context.Context, version int64, 
 				s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Keys: [format.MaxTags]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusErrSingle}}, time.Since(now).Seconds(), 1, false, format.BuiltinMetricIDAgentMapping)
 		}
 	*/
-	s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Tags: [format.MaxTags]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusOKFirst}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
+	s.AddValueCounter(&data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Tags: [format.MaxTags]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusOKFirst}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
 	return ret.Events, ret.CurrentVersion, nil
 }
 
@@ -206,7 +206,7 @@ func (s *Agent) LoadOrCreateMapping(ctxParent context.Context, key string, flood
 	// Use 2 alive random aggregators for mapping
 	s0, s1 := s.getRandomLiveShardReplicas()
 	if s0 == nil {
-		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Tags: [format.MaxTags]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusAllDead}}, 0, 1, format.BuiltinMetricMetaAgentMapping)
+		s.AddValueCounter(&data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Tags: [format.MaxTags]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusAllDead}}, 0, 1, format.BuiltinMetricMetaAgentMapping)
 		return nil, 0, fmt.Errorf("all aggregators are dead")
 	}
 	now := time.Now()
@@ -232,11 +232,11 @@ func (s *Agent) LoadOrCreateMapping(ctxParent context.Context, key string, flood
 	defer cancel()
 	err := s0.client.GetTagMapping2(ctx, args, &extra, &ret)
 	if err == nil {
-		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Tags: [format.MaxTags]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusOKFirst}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
+		s.AddValueCounter(&data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Tags: [format.MaxTags]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusOKFirst}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
 		return pcache.Int32ToValue(ret.Value), time.Duration(ret.TtlNanosec), nil
 	}
 	if s1 == nil {
-		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Tags: [format.MaxTags]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusErrSingle}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
+		s.AddValueCounter(&data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Tags: [format.MaxTags]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusErrSingle}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
 		return nil, 0, fmt.Errorf("the only live aggregator %q returned error: %w", s0.client.Address, err)
 	}
 
@@ -246,10 +246,10 @@ func (s *Agent) LoadOrCreateMapping(ctxParent context.Context, key string, flood
 	defer cancel2()
 	err2 := s1.client.GetTagMapping2(ctx2, args, &extra, &ret)
 	if err2 == nil {
-		s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Tags: [format.MaxTags]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusOKSecond}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
+		s.AddValueCounter(&data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Tags: [format.MaxTags]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusOKSecond}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
 		return pcache.Int32ToValue(ret.Value), time.Duration(ret.TtlNanosec), nil
 	}
-	s.AddValueCounter(data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Tags: [format.MaxTags]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusErrBoth}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
+	s.AddValueCounter(&data_model.Key{Metric: format.BuiltinMetricIDAgentMapping, Tags: [format.MaxTags]int32{0, format.TagValueIDAggMappingMetaMetrics, format.TagValueIDAgentMappingStatusErrBoth}}, time.Since(now).Seconds(), 1, format.BuiltinMetricMetaAgentMapping)
 	return nil, 0, fmt.Errorf("two live aggregators %q %q returned errors: %v %w", s0.client.Address, s1.client.Address, err, err2)
 }
 

--- a/internal/agent/agent_shard.go
+++ b/internal/agent/agent_shard.go
@@ -188,15 +188,15 @@ func (s *Shard) resolutionShardFromHashLocked(key *data_model.Key, keyHash uint6
 	return nextShard
 }
 
-func (s *Shard) CreateBuiltInItemValue(key data_model.Key) *BuiltInItemValue {
+func (s *Shard) CreateBuiltInItemValue(key *data_model.Key) *BuiltInItemValue {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	result := &BuiltInItemValue{key: key}
+	result := &BuiltInItemValue{key: *key}
 	s.BuiltInItemValues = append(s.BuiltInItemValues, result)
 	return result
 }
 
-func (s *Shard) ApplyUnique(key data_model.Key, keyHash uint64, str []byte, hashes []int64, count float64, hostTag int32, metricInfo *format.MetricMetaValue) {
+func (s *Shard) ApplyUnique(key *data_model.Key, keyHash uint64, str []byte, hashes []int64, count float64, hostTag int32, metricInfo *format.MetricMetaValue) {
 	if count == 0 {
 		count = float64(len(hashes))
 	}
@@ -208,13 +208,13 @@ func (s *Shard) ApplyUnique(key data_model.Key, keyHash uint64, str []byte, hash
 	if s.stopReceivingIncomingData {
 		return
 	}
-	resolutionShard := s.resolutionShardFromHashLocked(&key, keyHash, metricInfo)
+	resolutionShard := s.resolutionShardFromHashLocked(key, keyHash, metricInfo)
 	item, _ := resolutionShard.GetOrCreateMultiItem(key, s.config.StringTopCapacity, metricInfo)
 	mv := item.MapStringTopBytes(s.rng, str, count)
 	mv.ApplyUnique(s.rng, hashes, count, hostTag)
 }
 
-func (s *Shard) ApplyValues(key data_model.Key, keyHash uint64, str []byte, histogram [][2]float64, values []float64, count float64, hostTag int32, metricInfo *format.MetricMetaValue) {
+func (s *Shard) ApplyValues(key *data_model.Key, keyHash uint64, str []byte, histogram [][2]float64, values []float64, count float64, hostTag int32, metricInfo *format.MetricMetaValue) {
 	totalCount := float64(len(values))
 	for _, kv := range histogram {
 		totalCount += kv[1] // all counts are validated to be >= 0
@@ -230,13 +230,13 @@ func (s *Shard) ApplyValues(key data_model.Key, keyHash uint64, str []byte, hist
 	if s.stopReceivingIncomingData {
 		return
 	}
-	resolutionShard := s.resolutionShardFromHashLocked(&key, keyHash, metricInfo)
+	resolutionShard := s.resolutionShardFromHashLocked(key, keyHash, metricInfo)
 	item, _ := resolutionShard.GetOrCreateMultiItem(key, s.config.StringTopCapacity, metricInfo)
 	mv := item.MapStringTopBytes(s.rng, str, count)
 	mv.ApplyValues(s.rng, histogram, values, count, totalCount, hostTag, data_model.AgentPercentileCompression, metricInfo != nil && metricInfo.HasPercentiles)
 }
 
-func (s *Shard) ApplyCounter(key data_model.Key, keyHash uint64, str []byte, count float64, hostTag int32, metricInfo *format.MetricMetaValue) {
+func (s *Shard) ApplyCounter(key *data_model.Key, keyHash uint64, str []byte, count float64, hostTag int32, metricInfo *format.MetricMetaValue) {
 	if count <= 0 {
 		return
 	}
@@ -245,51 +245,51 @@ func (s *Shard) ApplyCounter(key data_model.Key, keyHash uint64, str []byte, cou
 	if s.stopReceivingIncomingData {
 		return
 	}
-	resolutionShard := s.resolutionShardFromHashLocked(&key, keyHash, metricInfo)
+	resolutionShard := s.resolutionShardFromHashLocked(key, keyHash, metricInfo)
 	item, _ := resolutionShard.GetOrCreateMultiItem(key, s.config.StringTopCapacity, metricInfo)
 	item.MapStringTopBytes(s.rng, str, count).AddCounterHost(s.rng, count, hostTag)
 }
 
-func (s *Shard) AddCounterHost(key data_model.Key, keyHash uint64, count float64, hostTagId int32, metricInfo *format.MetricMetaValue) {
+func (s *Shard) AddCounterHost(key *data_model.Key, keyHash uint64, count float64, hostTagId int32, metricInfo *format.MetricMetaValue) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.stopReceivingIncomingData {
 		return
 	}
-	resolutionShard := s.resolutionShardFromHashLocked(&key, keyHash, metricInfo)
+	resolutionShard := s.resolutionShardFromHashLocked(key, keyHash, metricInfo)
 	item, _ := resolutionShard.GetOrCreateMultiItem(key, s.config.StringTopCapacity, metricInfo)
 	item.Tail.AddCounterHost(s.rng, count, hostTagId)
 }
 
-func (s *Shard) AddCounterHostStringBytes(key data_model.Key, keyHash uint64, str []byte, count float64, hostTag int32, metricInfo *format.MetricMetaValue) {
+func (s *Shard) AddCounterHostStringBytes(key *data_model.Key, keyHash uint64, str []byte, count float64, hostTag int32, metricInfo *format.MetricMetaValue) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.stopReceivingIncomingData {
 		return
 	}
-	resolutionShard := s.resolutionShardFromHashLocked(&key, keyHash, metricInfo)
+	resolutionShard := s.resolutionShardFromHashLocked(key, keyHash, metricInfo)
 	item, _ := resolutionShard.GetOrCreateMultiItem(key, s.config.StringTopCapacity, metricInfo)
 	item.MapStringTopBytes(s.rng, str, count).AddCounterHost(s.rng, count, hostTag)
 }
 
-func (s *Shard) AddValueCounterHostStringBytes(key data_model.Key, keyHash uint64, value float64, count float64, hostTag int32, str []byte, metricInfo *format.MetricMetaValue) {
+func (s *Shard) AddValueCounterHostStringBytes(key *data_model.Key, keyHash uint64, value float64, count float64, hostTag int32, str []byte, metricInfo *format.MetricMetaValue) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.stopReceivingIncomingData {
 		return
 	}
-	resolutionShard := s.resolutionShardFromHashLocked(&key, keyHash, metricInfo)
+	resolutionShard := s.resolutionShardFromHashLocked(key, keyHash, metricInfo)
 	item, _ := resolutionShard.GetOrCreateMultiItem(key, s.config.StringTopCapacity, metricInfo)
 	item.MapStringTopBytes(s.rng, str, count).AddValueCounterHost(s.rng, value, count, hostTag)
 }
 
-func (s *Shard) AddValueCounterHost(key data_model.Key, keyHash uint64, value float64, counter float64, hostTag int32, metricInfo *format.MetricMetaValue) {
+func (s *Shard) AddValueCounterHost(key *data_model.Key, keyHash uint64, value float64, counter float64, hostTag int32, metricInfo *format.MetricMetaValue) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.stopReceivingIncomingData {
 		return
 	}
-	resolutionShard := s.resolutionShardFromHashLocked(&key, keyHash, metricInfo)
+	resolutionShard := s.resolutionShardFromHashLocked(key, keyHash, metricInfo)
 	item, _ := resolutionShard.GetOrCreateMultiItem(key, s.config.StringTopCapacity, metricInfo)
 	if metricInfo != nil && metricInfo.HasPercentiles {
 		item.Tail.AddValueCounterHostPercentile(s.rng, value, counter, hostTag, data_model.AgentPercentileCompression)
@@ -298,13 +298,13 @@ func (s *Shard) AddValueCounterHost(key data_model.Key, keyHash uint64, value fl
 	}
 }
 
-func (s *Shard) AddValueArrayCounterHost(key data_model.Key, keyHash uint64, values []float64, mult float64, hostTag int32, metricInfo *format.MetricMetaValue) {
+func (s *Shard) AddValueArrayCounterHost(key *data_model.Key, keyHash uint64, values []float64, mult float64, hostTag int32, metricInfo *format.MetricMetaValue) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.stopReceivingIncomingData {
 		return
 	}
-	resolutionShard := s.resolutionShardFromHashLocked(&key, keyHash, metricInfo)
+	resolutionShard := s.resolutionShardFromHashLocked(key, keyHash, metricInfo)
 	item, _ := resolutionShard.GetOrCreateMultiItem(key, s.config.StringTopCapacity, metricInfo)
 	if metricInfo != nil && metricInfo.HasPercentiles {
 		item.Tail.AddValueArrayHostPercentile(s.rng, values, mult, hostTag, data_model.AgentPercentileCompression)
@@ -313,13 +313,13 @@ func (s *Shard) AddValueArrayCounterHost(key data_model.Key, keyHash uint64, val
 	}
 }
 
-func (s *Shard) AddValueArrayCounterHostStringBytes(key data_model.Key, keyHash uint64, values []float64, mult float64, hostTag int32, str []byte, metricInfo *format.MetricMetaValue) {
+func (s *Shard) AddValueArrayCounterHostStringBytes(key *data_model.Key, keyHash uint64, values []float64, mult float64, hostTag int32, str []byte, metricInfo *format.MetricMetaValue) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.stopReceivingIncomingData {
 		return
 	}
-	resolutionShard := s.resolutionShardFromHashLocked(&key, keyHash, metricInfo)
+	resolutionShard := s.resolutionShardFromHashLocked(key, keyHash, metricInfo)
 	item, _ := resolutionShard.GetOrCreateMultiItem(key, s.config.StringTopCapacity, metricInfo)
 	count := float64(len(values)) * mult
 	if metricInfo != nil && metricInfo.HasPercentiles {
@@ -329,13 +329,13 @@ func (s *Shard) AddValueArrayCounterHostStringBytes(key data_model.Key, keyHash 
 	}
 }
 
-func (s *Shard) MergeItemValue(key data_model.Key, keyHash uint64, itemValue *data_model.ItemValue, metricInfo *format.MetricMetaValue) {
+func (s *Shard) MergeItemValue(key *data_model.Key, keyHash uint64, itemValue *data_model.ItemValue, metricInfo *format.MetricMetaValue) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.stopReceivingIncomingData {
 		return
 	}
-	resolutionShard := s.resolutionShardFromHashLocked(&key, keyHash, metricInfo)
+	resolutionShard := s.resolutionShardFromHashLocked(key, keyHash, metricInfo)
 	item, _ := resolutionShard.GetOrCreateMultiItem(key, s.config.StringTopCapacity, metricInfo)
 	item.Tail.Value.Merge(s.rng, itemValue)
 }
@@ -348,7 +348,7 @@ func (s *Shard) addBuiltInsLocked(nowUnix uint32) {
 	for _, v := range s.BuiltInItemValues {
 		v.mu.Lock()
 		if v.value.Count() > 0 {
-			item, _ := resolutionShard.GetOrCreateMultiItem(v.key, s.config.StringTopCapacity, nil)
+			item, _ := resolutionShard.GetOrCreateMultiItem(&v.key, s.config.StringTopCapacity, nil)
 			item.Tail.Value.Merge(s.rng, &v.value)
 			v.value = data_model.ItemValue{} // Moving below 'if' would reset Counter if <0. Will complicate debugging, so no.
 		}

--- a/internal/agent/agent_shard_send.go
+++ b/internal/agent/agent_shard_send.go
@@ -65,7 +65,7 @@ func (s *Shard) flushBuckets(now time.Time) {
 					Metric:    format.BuiltinMetricIDTimingErrors,
 					Tags:      [format.MaxTags]int32{0, format.TagValueIDTimingMissedSecondsAgent},
 				}
-				mi, _ := b.GetOrCreateMultiItem(key, s.config.StringTopCapacity, nil)
+				mi, _ := b.GetOrCreateMultiItem(&key, s.config.StringTopCapacity, nil)
 				mi.Tail.AddValueCounterHost(s.rng, float64(currentTimeRounded+uint32(r)-b.Time), 1, 0) // values record jumps f more than 1 second
 			}
 			b.Time = currentTimeRounded + uint32(r)
@@ -240,7 +240,7 @@ func (s *Shard) mergeBuckets(rng *rand.Rand, bucket *data_model.MetricsBucket, b
 	}
 	for _, b := range buckets {
 		for _, item := range b.MultiItems {
-			mi, _ := bucket.GetOrCreateMultiItem(item.Key, stringTopCapacity, nil)
+			mi, _ := bucket.GetOrCreateMultiItem(&item.Key, stringTopCapacity, nil)
 			mi.Merge(rng, item)
 		}
 	}
@@ -294,24 +294,24 @@ func (s *Shard) sampleBucket(bucket *data_model.MetricsBucket, rnd *rand.Rand) [
 	for _, v := range sampler.MetricGroups {
 		// keep bytes
 		key := data_model.Key{Metric: format.BuiltinMetricIDSrcSamplingSizeBytes, Tags: [format.MaxTags]int32{0, s.agent.componentTag, format.TagValueIDSamplingDecisionKeep, v.NamespaceID, v.GroupID, v.MetricID}}
-		item, _ := bucket.GetOrCreateMultiItem(key, config.StringTopCapacity, nil)
+		item, _ := bucket.GetOrCreateMultiItem(&key, config.StringTopCapacity, nil)
 		item.Tail.Value.Merge(rnd, &v.SumSizeKeep)
 		// discard bytes
 		key = data_model.Key{Metric: format.BuiltinMetricIDSrcSamplingSizeBytes, Tags: [format.MaxTags]int32{0, s.agent.componentTag, format.TagValueIDSamplingDecisionDiscard, v.NamespaceID, v.GroupID, v.MetricID}}
-		item, _ = bucket.GetOrCreateMultiItem(key, config.StringTopCapacity, nil)
+		item, _ = bucket.GetOrCreateMultiItem(&key, config.StringTopCapacity, nil)
 		item.Tail.Value.Merge(rnd, &v.SumSizeDiscard)
 		// budget
 		key = data_model.Key{Metric: format.BuiltinMetricIDSrcSamplingGroupBudget, Tags: [format.MaxTags]int32{0, s.agent.componentTag, v.NamespaceID, v.GroupID}}
-		item, _ = bucket.GetOrCreateMultiItem(key, config.StringTopCapacity, nil)
+		item, _ = bucket.GetOrCreateMultiItem(&key, config.StringTopCapacity, nil)
 		item.Tail.Value.AddValue(v.Budget())
 	}
 	// report budget used
 	budgetKey := data_model.Key{Metric: format.BuiltinMetricIDSrcSamplingBudget, Tags: [format.MaxTags]int32{0, s.agent.componentTag}}
-	budgetItem, _ := bucket.GetOrCreateMultiItem(budgetKey, config.StringTopCapacity, nil)
+	budgetItem, _ := bucket.GetOrCreateMultiItem(&budgetKey, config.StringTopCapacity, nil)
 	budgetItem.Tail.Value.AddValue(float64(remainingBudget))
 	// metric count
 	key := data_model.Key{Metric: format.BuiltinMetricIDSrcSamplingMetricCount, Tags: [format.MaxTags]int32{0, s.agent.componentTag}}
-	item, _ := bucket.GetOrCreateMultiItem(key, config.StringTopCapacity, nil)
+	item, _ := bucket.GetOrCreateMultiItem(&key, config.StringTopCapacity, nil)
 	item.Tail.Value.AddValueCounterHost(rnd, float64(sampler.MetricCount), 1, 0)
 	return sampler.SampleFactors
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -84,16 +84,16 @@ func Test_AgentQueue(t *testing.T) {
 	testEnsureNoFlush(t, shard)
 	agent.goFlushIteration(startTime.Add(time.Second))
 	testEnsureNoFlush(t, shard)
-	agent.AddCounterHost(data_model.Key{Timestamp: nowUnix, Metric: 1}, 1, 0, metric1sec)
-	agent.AddCounterHost(data_model.Key{Timestamp: nowUnix, Metric: 5}, 1, 0, metric5sec)
-	agent.AddCounterHost(data_model.Key{Timestamp: nowUnix + 1, Metric: 1}, 1, 0, metric1sec)
-	agent.AddCounterHost(data_model.Key{Timestamp: nowUnix + 1, Metric: 5}, 1, 0, metric5sec)
+	agent.AddCounterHost(&data_model.Key{Timestamp: nowUnix, Metric: 1}, 1, 0, metric1sec)
+	agent.AddCounterHost(&data_model.Key{Timestamp: nowUnix, Metric: 5}, 1, 0, metric5sec)
+	agent.AddCounterHost(&data_model.Key{Timestamp: nowUnix + 1, Metric: 1}, 1, 0, metric1sec)
+	agent.AddCounterHost(&data_model.Key{Timestamp: nowUnix + 1, Metric: 5}, 1, 0, metric5sec)
 	agent.goFlushIteration(startTime.Add(time.Second + data_model.AgentWindow))
 	testEnsureFlush(t, shard, nowUnix)
-	agent.AddCounterHost(data_model.Key{Timestamp: nowUnix + 1, Metric: 1}, 1, 0, metric1sec)
-	agent.AddCounterHost(data_model.Key{Timestamp: nowUnix + 1, Metric: 5}, 1, 0, metric5sec)
-	agent.AddCounterHost(data_model.Key{Timestamp: nowUnix + 2, Metric: 1}, 1, 0, metric1sec)
-	agent.AddCounterHost(data_model.Key{Timestamp: nowUnix + 2, Metric: 5}, 1, 0, metric5sec)
+	agent.AddCounterHost(&data_model.Key{Timestamp: nowUnix + 1, Metric: 1}, 1, 0, metric1sec)
+	agent.AddCounterHost(&data_model.Key{Timestamp: nowUnix + 1, Metric: 5}, 1, 0, metric5sec)
+	agent.AddCounterHost(&data_model.Key{Timestamp: nowUnix + 2, Metric: 1}, 1, 0, metric1sec)
+	agent.AddCounterHost(&data_model.Key{Timestamp: nowUnix + 2, Metric: 5}, 1, 0, metric5sec)
 	agent.goFlushIteration(startTime.Add(2 * time.Second))
 	testEnsureNoFlush(t, shard)
 	for i := 1; i < 12; i++ { // wait until 5-seconds metrics flushed
@@ -228,11 +228,11 @@ func Test_AgentSharding(t *testing.T) {
 					shardCount += int(item.Tail.Value.Count())
 					expectedShardNum := uint32(0) // buitin metrics
 					if item.Key.Metric > 0 && item.Key.Metric < 300_001 {
-						expectedShardNum, _, _ = sharding.Shard(item.Key, item.Key.Hash(), fixedShard(nil, item.Key), agent.NumShards(), true)
+						expectedShardNum, _, _ = sharding.Shard(&item.Key, item.Key.Hash(), fixedShard(nil, item.Key), agent.NumShards(), true)
 					} else if item.Key.Metric >= 300_001 {
-						expectedShardNum, _, _ = sharding.Shard(item.Key, item.Key.Hash(), byMappedTags(nil, item.Key), agent.NumShards(), true)
+						expectedShardNum, _, _ = sharding.Shard(&item.Key, item.Key.Hash(), byMappedTags(nil, item.Key), agent.NumShards(), true)
 					} else if item.Key.Metric == format.BuiltinMetricIDIngestionStatus {
-						expectedShardNum, _, _ = sharding.Shard(item.Key, item.Key.Hash(), byTagIngestion, agent.NumShards(), true)
+						expectedShardNum, _, _ = sharding.Shard(&item.Key, item.Key.Hash(), byTagIngestion, agent.NumShards(), true)
 					}
 					if int(expectedShardNum) != si {
 						t.Fatalf("failed for metric %v expected shard %d but got %d", item.Key, expectedShardNum, si)

--- a/internal/aggregator/aggregator_log.go
+++ b/internal/aggregator/aggregator_log.go
@@ -68,7 +68,7 @@ func (a *Aggregator) goInternalLog() {
 	}
 }
 
-func (a *Aggregator) reportInsertKeys(bucketTime uint32, metric int32, historic bool, err error, status int, exception int) data_model.Key {
+func (a *Aggregator) reportInsertKeys(bucketTime uint32, metric int32, historic bool, err error, status int, exception int) *data_model.Key {
 	key := a.aggKey(bucketTime, metric, [16]int32{0, 0, 0, 0, format.TagValueIDConveyorRecent, format.TagValueIDInsertTimeOK, int32(status), int32(exception)})
 	if err != nil {
 		key.Tags[5] = format.TagValueIDInsertTimeError
@@ -79,7 +79,7 @@ func (a *Aggregator) reportInsertKeys(bucketTime uint32, metric int32, historic 
 	return key
 }
 
-func (a *Aggregator) reportExpInsertKeys(bucketTime uint32, metric int32, historic bool, err error, status int, exception int) data_model.Key {
+func (a *Aggregator) reportExpInsertKeys(bucketTime uint32, metric int32, historic bool, err error, status int, exception int) *data_model.Key {
 	key := a.aggKey(bucketTime, metric, [16]int32{0, 0, 0, 0, format.TagValueIDConveyorRecent, format.TagValueIDInsertTimeOK, int32(status), int32(exception), 1})
 	if err != nil {
 		key.Tags[5] = format.TagValueIDInsertTimeError

--- a/internal/aggregator/ingress_proxy2.go
+++ b/internal/aggregator/ingress_proxy2.go
@@ -412,7 +412,7 @@ func (p *proxyConn) requestLoop(ctx context.Context, req proxyRequest) (_ proxyR
 	for i := uint(0); ; i++ {
 		// request (tip) must be set except maybe graceful shutdown first iteration
 		if i > 0 || req.tip != 0 {
-			p.agent.AddValueCounter(requestSize, float64(len(req.Request)), 1, format.BuiltinMetricMetaRPCRequests)
+			p.agent.AddValueCounter(&requestSize, float64(len(req.Request)), 1, format.BuiltinMetricMetaRPCRequests)
 			p.reportRequestBufferSizeChange()
 			switch req.tip {
 			case rpcInvokeReqHeaderTLTag:

--- a/internal/aggregator/simulator.go
+++ b/internal/aggregator/simulator.go
@@ -158,7 +158,7 @@ func RunSimulator(simID int, metricsStorage *metajournal.MetricsStorage, storage
 }
 
 func generateStats(simID int, journal *metajournal.MetricsStorage, s *agent.Agent, totalRange int, key1range int32, key2range int32, key3range int32) {
-	mag := s.CreateBuiltInItemValue(data_model.Key{Metric: 100, Tags: [16]int32{0, int32(simID)}}, journal.GetMetaMetric(100))
+	mag := s.CreateBuiltInItemValue(&data_model.Key{Metric: 100, Tags: [16]int32{0, int32(simID)}}, journal.GetMetaMetric(100))
 
 	metricInfo1 := journal.GetMetaMetricByName(data_model.SimulatorMetricPrefix + "1")
 	metricInfo2 := journal.GetMetaMetricByName(data_model.SimulatorMetricPrefix + "2")
@@ -190,7 +190,7 @@ func generateStats(simID int, journal *metajournal.MetricsStorage, s *agent.Agen
 			kCounter1.Tags[3] = rng.Int31n(key3range)
 			cc := 1 + rng.Intn(4)
 			oneCounter += cc
-			s.AddCounterHost(kCounter1, float64(cc), 0, metricInfo1)
+			s.AddCounterHost(&kCounter1, float64(cc), 0, metricInfo1)
 		}
 		if spike {
 			for i := 0; i < totalRange; i++ {
@@ -200,14 +200,14 @@ func generateStats(simID int, journal *metajournal.MetricsStorage, s *agent.Agen
 				kCounter1.Tags[4] = rng.Int31n(int32(totalRange))
 				cc := 1 + rng.Intn(4)
 				oneCounter += cc
-				s.AddCounterHost(kCounter1, float64(cc), 0, metricInfo1)
+				s.AddCounterHost(&kCounter1, float64(cc), 0, metricInfo1)
 			}
 		}
 		if oneCounter < 3*totalRange*5 {
 			kCounter1 := data_model.Key{
 				Metric: metricInfo1.MetricID,
 			}
-			s.AddCounterHost(kCounter1, float64(3*totalRange*5-oneCounter), 0, metricInfo1)
+			s.AddCounterHost(&kCounter1, float64(3*totalRange*5-oneCounter), 0, metricInfo1)
 		}
 
 		total = rng.Intn(totalRange)
@@ -232,10 +232,10 @@ func generateStats(simID int, journal *metajournal.MetricsStorage, s *agent.Agen
 			cc := 1 + rng.Intn(4)
 			for ci := 0; ci < cc; ci++ {
 				value := rng.Float64() * 100
-				s.AddValueCounter(kValue2, value, 1, metricInfo2)
-				s.AddValueCounter(kValue3, value, 1, metricInfo3)
-				s.AddValueArrayCounterHostStringBytes(kValue10, []float64{value}, 1, 0, sKey, metricInfo10)
-				s.AddValueArrayCounterHostStringBytes(kValue11, []float64{value}, 1, 0, sKey, metricInfo11)
+				s.AddValueCounter(&kValue2, value, 1, metricInfo2)
+				s.AddValueCounter(&kValue3, value, 1, metricInfo3)
+				s.AddValueArrayCounterHostStringBytes(&kValue10, []float64{value}, 1, 0, sKey, metricInfo10)
+				s.AddValueArrayCounterHostStringBytes(&kValue11, []float64{value}, 1, 0, sKey, metricInfo11)
 			}
 		}
 		total = rng.Intn(totalRange)
@@ -259,9 +259,9 @@ func generateStats(simID int, journal *metajournal.MetricsStorage, s *agent.Agen
 			for ci := 0; ci < cc; ci++ {
 				const D = 1000000
 				r := D + int64(rng.Intn(D))*int64(rng.Intn(D))
-				s.AddUniqueHostStringBytes(kUnique4, 0, nil, []int64{r}, 1, metricInfo4)
-				s.AddUniqueHostStringBytes(kUnique7, 0, nil, []int64{r}, 1, metricInfo7)
-				s.AddUniqueHostStringBytes(kUnique8, 0, sKey, []int64{r}, 1, metricInfo8)
+				s.AddUniqueHostStringBytes(&kUnique4, 0, nil, []int64{r}, 1, metricInfo4)
+				s.AddUniqueHostStringBytes(&kUnique7, 0, nil, []int64{r}, 1, metricInfo7)
+				s.AddUniqueHostStringBytes(&kUnique8, 0, sKey, []int64{r}, 1, metricInfo8)
 			}
 		}
 
@@ -274,11 +274,11 @@ func generateStats(simID int, journal *metajournal.MetricsStorage, s *agent.Agen
 			kValue5.Tags[2] = rng.Int31n(key2range)
 			sid := rng.Intn(len(stop) * 100)
 			if sid < len(stop) {
-				s.AddCounterHostStringBytes(kValue5, stop[sid], 1, 0, metricInfo5)
+				s.AddCounterHostStringBytes(&kValue5, stop[sid], 1, 0, metricInfo5)
 				continue
 			}
 			cc := 1 + rng.Intn(100000)
-			s.AddCounterHostStringBytes(kValue5, []byte(fmt.Sprintf("A_%d", cc)), 1, 0, metricInfo5)
+			s.AddCounterHostStringBytes(&kValue5, []byte(fmt.Sprintf("A_%d", cc)), 1, 0, metricInfo5)
 		}
 		total = rng.Intn(totalRange)
 		superTotal += total
@@ -290,10 +290,10 @@ func generateStats(simID int, journal *metajournal.MetricsStorage, s *agent.Agen
 			kCounter6.Tags[2] = rng.Int31n(key2range)
 			kCounter6.Tags[3] = rng.Int31n(key3range)
 			kCounter6.Tags[4] = rng.Int31n(1000)
-			s.AddCounterHost(kCounter6, 1, 0, metricInfo6)
+			s.AddCounterHost(&kCounter6, 1, 0, metricInfo6)
 		}
 
-		s.AddCounterHost(data_model.Key{Metric: metricInfo9.MetricID}, float64(superTotal), 0, metricInfo9)
+		s.AddCounterHost(&data_model.Key{Metric: metricInfo9.MetricID}, float64(superTotal), 0, metricInfo9)
 		// msec := rng.Int() % 1000
 		// time.Sleep(time.Duration(msec) * time.Millisecond)
 		time.Sleep(time.Second)

--- a/internal/aggregator/tags_mapper.go
+++ b/internal/aggregator/tags_mapper.go
@@ -154,7 +154,7 @@ func (ms *TagsMapper) mapOrFlood(now time.Time, value []byte, metricName string,
 }
 
 // safe only to access fields mask in args, other fields point to reused memory
-func (ms *TagsMapper) sendCreateTagMappingResult(hctx *rpc.HandlerContext, args tlstatshouse.GetTagMapping2Bytes, r pcache.Result, key data_model.Key, meta *format.MetricMetaValue) (err error) {
+func (ms *TagsMapper) sendCreateTagMappingResult(hctx *rpc.HandlerContext, args tlstatshouse.GetTagMapping2Bytes, r pcache.Result, key *data_model.Key, meta *format.MetricMetaValue) (err error) {
 	if r.Err != nil {
 		key.Tags[5] = format.TagValueIDAggMappingStatusErrUncached
 		ms.sh2.AddCounter(key, 1, meta)

--- a/internal/data_model/bucket.go
+++ b/internal/data_model/bucket.go
@@ -133,7 +133,7 @@ func (k *Key) Marshal(buffer []byte) (updatedBuffer []byte, newKey []byte) {
 	return
 }
 
-func (k Key) WithAgentEnvRouteArch(agentEnvTag int32, routeTag int32, buildArchTag int32) Key {
+func (k *Key) WithAgentEnvRouteArch(agentEnvTag int32, routeTag int32, buildArchTag int32) *Key {
 	// when aggregator receives metric from an agent inside another aggregator, those keys are already set,
 	// so we simply keep them. AgentEnvTag or RouteTag are always non-zero in this case.
 	if k.Tags[format.AgentEnvTag] == 0 {
@@ -144,12 +144,12 @@ func (k Key) WithAgentEnvRouteArch(agentEnvTag int32, routeTag int32, buildArchT
 	return k
 }
 
-func AggKey(t uint32, m int32, k [format.MaxTags]int32, hostTagId int32, shardTag int32, replicaTag int32) Key {
+func AggKey(t uint32, m int32, k [format.MaxTags]int32, hostTagId int32, shardTag int32, replicaTag int32) *Key {
 	key := Key{Timestamp: t, Metric: m, Tags: k}
 	key.Tags[format.AggHostTag] = hostTagId
 	key.Tags[format.AggShardTag] = shardTag
 	key.Tags[format.AggReplicaTag] = replicaTag
-	return key
+	return &key
 }
 
 func (k *Key) Hash() uint64 {
@@ -255,7 +255,7 @@ func (b *MetricsBucket) Empty() bool {
 	return len(b.MultiItems) == 0
 }
 
-func (b *MultiItemMap) GetOrCreateMultiItem(key Key, stringTopCapacity int, metricInfo *format.MetricMetaValue) (item *MultiItem, created bool) {
+func (b *MultiItemMap) GetOrCreateMultiItem(key *Key, stringTopCapacity int, metricInfo *format.MetricMetaValue) (item *MultiItem, created bool) {
 	if b.MultiItems == nil {
 		b.MultiItems = make(map[string]*MultiItem)
 	}
@@ -268,7 +268,7 @@ func (b *MultiItemMap) GetOrCreateMultiItem(key Key, stringTopCapacity int, metr
 		b.keysBuffer = b.keysBuffer[:len(b.keysBuffer)-len(keyBytes)]
 		return
 	}
-	item = &MultiItem{Key: key, Capacity: stringTopCapacity, SF: 1, MetricMeta: metricInfo}
+	item = &MultiItem{Key: *key, Capacity: stringTopCapacity, SF: 1, MetricMeta: metricInfo}
 	b.MultiItems[keyString] = item
 	return
 }

--- a/internal/data_model/estimator.go
+++ b/internal/data_model/estimator.go
@@ -48,7 +48,7 @@ func (e *Estimator) Init(window int, maxCardinality int) {
 	e.halfHour = map[uint32]map[int32]*ChUnique{}
 }
 
-func (e *Estimator) UpdateWithKeys(time uint32, keys []Key) {
+func (e *Estimator) UpdateWithKeys(time uint32, keys []*Key) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	ah, bh := e.createEstimatorsLocked(time)

--- a/internal/data_model/sampling_test.go
+++ b/internal/data_model/sampling_test.go
@@ -220,7 +220,7 @@ func TestFairKeySampling(t *testing.T) {
 			for j := 1; j <= v; j++ {
 				key.Tags[1] = int32(j)
 				v := &MultiItem{}
-				mi, _ := b.GetOrCreateMultiItem(key, 0, nil)
+				mi, _ := b.GetOrCreateMultiItem(&key, 0, nil)
 				mi.Tail.Value.AddValueCounter(0, 1)
 				b.sumSize += int64(key.TLSizeEstimate(key.Timestamp) + v.TLSizeEstimate())
 			}
@@ -418,7 +418,7 @@ func (b *samplingTestBucket) generateSeriesCount(t *rapid.T, s samplingTestSpec)
 			var (
 				k = Key{Metric: metricID, Tags: [format.MaxTags]int32{int32(i + 1)}}
 			)
-			mi, _ := miMap.GetOrCreateMultiItem(k, 0, nil)
+			mi, _ := miMap.GetOrCreateMultiItem(&k, 0, nil)
 			mi.Tail.Value.AddValueCounter(0, 1)
 			sumSize += int64(k.TLSizeEstimate(k.Timestamp) + mi.TLSizeEstimate())
 		}
@@ -442,7 +442,7 @@ func (b *samplingTestBucket) generateSeriesSize(t *rapid.T, s samplingTestSpec) 
 		)
 		for i := int32(1); size < sizeT; i++ {
 			var k = Key{Metric: metricID, Tags: [format.MaxTags]int32{i}}
-			item, _ := miMap.GetOrCreateMultiItem(k, 0, nil)
+			item, _ := miMap.GetOrCreateMultiItem(&k, 0, nil)
 			item.Tail.Value.AddValueCounter(0, 1)
 			size += samplingTestSizeOf(item)
 		}
@@ -536,7 +536,7 @@ func benchmarkSampleBucket(b *testing.B, f func(*MetricsBucket, samplerConfigEx)
 			var (
 				k = Key{Metric: metricID, Tags: [format.MaxTags]int32{int32(i + 1)}}
 			)
-			mi, _ := bucket.GetOrCreateMultiItem(k, 0, nil)
+			mi, _ := bucket.GetOrCreateMultiItem(&k, 0, nil)
 			mi.Tail.Value.AddValueCounter(0, 1)
 		}
 	}

--- a/internal/data_model/transfer.go
+++ b/internal/data_model/transfer.go
@@ -28,9 +28,10 @@ func (k *Key) TagSlice() []int32 {
 	return result[:i]
 }
 
-func KeyFromStatshouseMultiItem(item *tlstatshouse.MultiItemBytes, bucketTimestamp uint32, newestTime uint32) (key Key, shardID int) {
+func KeyFromStatshouseMultiItem(item *tlstatshouse.MultiItemBytes, bucketTimestamp uint32, newestTime uint32) (key *Key, shardID int) {
 	// We use high byte of fieldsmask to pass shardID to aggregator, otherwise it is too much work for CPU
 	sID := item.FieldsMask >> 24
+	key = &Key{}
 	key.Timestamp = bucketTimestamp
 	if item.IsSetT() {
 		key.Timestamp = item.T

--- a/internal/data_model/transfer_test.go
+++ b/internal/data_model/transfer_test.go
@@ -176,7 +176,7 @@ func TestKeySizeEstimationEdgeCases(t *testing.T) {
 }
 
 // Helper function to convert Key to MultiItemBytes and back
-func roundTripKey(key Key, bucketTimestamp uint32, newestTime uint32) Key {
+func roundTripKey(key Key, bucketTimestamp uint32, newestTime uint32) *Key {
 	// Convert Key to MultiItem
 	item := key.TLMultiItemFromKey(bucketTimestamp)
 

--- a/internal/receiver/receiver.go
+++ b/internal/receiver/receiver.go
@@ -143,7 +143,7 @@ func (u *parser) createMetrics() {
 
 func createBatchSizeValue(ag *agent.Agent, formatTagValueID int32, statusTagValueID int32, protocolTagValueID int32) *agent.BuiltInItemValue {
 	if ag != nil {
-		return ag.CreateBuiltInItemValue(data_model.Key{
+		return ag.CreateBuiltInItemValue(&data_model.Key{
 			Metric: format.BuiltinMetricIDAgentReceivedBatchSize,
 			Tags:   [format.MaxTags]int32{0 /* env */, formatTagValueID, statusTagValueID, protocolTagValueID},
 		}, format.BuiltinMetricMetaAgentReceivedBatchSize)
@@ -153,7 +153,7 @@ func createBatchSizeValue(ag *agent.Agent, formatTagValueID int32, statusTagValu
 
 func createPacketSizeValue(bm *agent.Agent, formatTagValueID int32, statusTagValueID int32, protocolTagValueID int32) *agent.BuiltInItemValue {
 	if bm != nil {
-		return bm.CreateBuiltInItemValue(data_model.Key{
+		return bm.CreateBuiltInItemValue(&data_model.Key{
 			Metric: format.BuiltinMetricIDAgentReceivedPacketSize,
 			Tags:   [format.MaxTags]int32{0 /* env */, formatTagValueID, statusTagValueID, protocolTagValueID},
 		}, format.BuiltinMetricMetaAgentReceivedPacketSize)

--- a/internal/sharding/sharding.go
+++ b/internal/sharding/sharding.go
@@ -8,7 +8,7 @@ import (
 	"github.com/vkcom/statshouse/internal/format"
 )
 
-func Shard(key data_model.Key, keyHash uint64, meta *format.MetricMetaValue, numShards int, builtinNewSharding bool) (uint32, int, error) {
+func Shard(key *data_model.Key, keyHash uint64, meta *format.MetricMetaValue, numShards int, builtinNewSharding bool) (uint32, int, error) {
 	if len(meta.Sharding) == 0 {
 		return 0, -1, fmt.Errorf("bad metric meta, no sharding defined")
 	}
@@ -49,15 +49,15 @@ func shardByMappedTags(keyHash uint64, numShards int) uint32 {
 	return uint32(mul)
 }
 
-func shardByTag(key data_model.Key, tagId uint32, numShards int) uint32 {
+func shardByTag(key *data_model.Key, tagId uint32, numShards int) uint32 {
 	return uint32(key.Tags[tagId]) % uint32(numShards)
 }
 
-func shardByMetricId(key data_model.Key, numShards int) uint32 {
+func shardByMetricId(key *data_model.Key, numShards int) uint32 {
 	return uint32(key.Metric) % uint32(numShards)
 }
 
-func choseShardingStrategy(key data_model.Key, meta *format.MetricMetaValue) (sh format.MetricSharding) {
+func choseShardingStrategy(key *data_model.Key, meta *format.MetricMetaValue) (sh format.MetricSharding) {
 	ts := key.Timestamp
 	if ts == 0 {
 		ts = uint32(time.Now().Unix())

--- a/internal/sharding/sharding_test.go
+++ b/internal/sharding/sharding_test.go
@@ -73,7 +73,7 @@ func TestShard(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotShard, gotStrategy, err := Shard(tt.args.key, tt.args.key.Hash(), tt.args.meta, tt.args.numShards, tt.args.builtinNewSharding)
+			gotShard, gotStrategy, err := Shard(&tt.args.key, tt.args.key.Hash(), tt.args.meta, tt.args.numShards, tt.args.builtinNewSharding)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Shard() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/vkcom/statshouse/internal/agent
cpu: Apple M3 Max
                  │ master.txt  │             key-ptr.txt             │
                  │   sec/op    │   sec/op     vs base                │
_AgentApplyMetric   1.262µ ± 4%   1.167µ ± 2%  -7.49% (p=0.000 n=100)

                  │  master.txt  │           key-ptr.txt           │
                  │     B/op     │     B/op      vs base           │
_AgentApplyMetric   1.398Ki ± 0%   1.398Ki ± 0%  ~ (p=0.957 n=100)

                  │ master.txt │           key-ptr.txt           │
                  │ allocs/op  │ allocs/op   vs base             │
_AgentApplyMetric   2.000 ± 0%   2.000 ± 0%  ~ (p=1.000 n=100) ¹
¹ all samples are equal
```