### PR TITLE
Update grouping by all tags

### DIFF
--- a/internal/promql/engine.go
+++ b/internal/promql/engine.go
@@ -1096,7 +1096,7 @@ func (ev *evaluator) buildSeriesQuery(ctx context.Context, sel *parser.VectorSel
 		groupBy = ev.opt.GroupBy
 	} else if sel.GroupByAll {
 		if !sel.GroupWithout {
-			for i := 0; i < format.NewMaxTags; i++ {
+			for i := 0; i < format.MaxTags; i++ {
 				groupBy = append(groupBy, format.TagID(i))
 			}
 			groupBy = append(groupBy, format.StringTopTagID)
@@ -1109,7 +1109,7 @@ func (ev *evaluator) buildSeriesQuery(ctx context.Context, sel *parser.VectorSel
 				skip[t.Index] = true
 			}
 		}
-		for i := 0; i < format.NewMaxTags; i++ {
+		for i := 0; i < format.MaxTags; i++ {
 			if !skip[i] {
 				groupBy = append(groupBy, format.TagID(i))
 			}


### PR DESCRIPTION
Group by all covers 16 tags until v3 migration completed