### PR TITLE
Revert

### DIFF
--- a/internal/api/sql.go
+++ b/internal/api/sql.go
@@ -60,7 +60,7 @@ func (pq *pointsQuery) cacheKey() string {
 	case Version1:
 		sb.WriteString(Version1)
 	default:
-		sb.WriteString(Version3)
+		sb.WriteString(Version2)
 	}
 	sb.WriteString(";m=")
 	sb.WriteString(fmt.Sprint(pq.metricID))

--- a/internal/data_model/timescale.go
+++ b/internal/data_model/timescale.go
@@ -259,15 +259,6 @@ var (
 
 var errQueryOutOfRange = fmt.Errorf("exceeded maximum resolution of %d points per timeseries", MaxSlice)
 
-func CacheDropInterval(version string) time.Duration {
-	switch version {
-	case Version1:
-		return 90 * time.Second
-	default:
-		return 0
-	}
-}
-
 func GetTimescale(args GetTimescaleArgs) (Timescale, error) {
 	if args.End <= args.Start || args.Step < 0 {
 		return Timescale{}, nil


### PR DESCRIPTION
c59847386011a3085f014adb7b53692da4f652d7
1d6e88d0d3e37012517811eb5897630a038a4fbf
cf6d4881eb0b5d5c64719f36e5c0fc7928dacd4c