### PR TITLE
Gbuteyko/agent super queue

### DIFF
--- a/.run/agent.run.xml
+++ b/.run/agent.run.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="agent" type="GoApplicationRunConfiguration" factoryName="Go Application">
     <module name="statshouse" />
     <working_directory value="$PROJECT_DIR$/localdebug" />
-    <parameters value="-agent --hardware-metric-scrape-disable --cluster=default --hostname=agent1 --agg-addr=127.0.0.1:13336,127.0.0.1:13346,127.0.0.1:13356 --cache-dir=cache/agent" />
+    <parameters value="-agent --hardware-metric-scrape-disable --cluster=statlogs2 --hostname=agent1 --agg-addr=127.0.0.1:13336,127.0.0.1:13346,127.0.0.1:13356 --cache-dir=cache/agent" />
     <kind value="PACKAGE" />
     <package value="github.com/vkcom/statshouse/cmd/statshouse" />
     <directory value="$PROJECT_DIR$" />

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -74,10 +74,9 @@ type Agent struct {
 
 	metricStorage format.MetaStorageInterface
 
-	componentTag    int32 // agent or ingress proxy or aggregator (they have agents for built-in metrics)
-	stagingLevel    int
-	commitTimestamp int32
-	buildArchTag    int32
+	componentTag int32 // agent or ingress proxy or aggregator (they have agents for built-in metrics)
+	stagingLevel int
+	buildArchTag int32
 	// Used for builtin metrics when running inside aggregator
 	AggregatorShardKey   int32
 	AggregatorReplicaKey int32
@@ -139,7 +138,6 @@ func MakeAgent(network string, storageDir string, aesPwd string, config Config, 
 		argsLen:               int32(len(allArgs)),
 		args:                  string(format.ForceValidStringValue(allArgs)), // if single arg is too big, it is truncated here
 		logF:                  logF,
-		commitTimestamp:       int32(build.CommitTimestamp()),
 		buildArchTag:          format.GetBuildArchKey(runtime.GOARCH),
 		metricStorage:         metricStorage,
 		beforeFlushBucketFunc: beforeFlushBucketFunc,
@@ -256,13 +254,13 @@ func (s *Agent) initBuiltInMetrics() {
 	s.statDiskOverflow = s.CreateBuiltInItemValue(&data_model.Key{Metric: format.BuiltinMetricIDTimingErrors, Tags: [format.MaxTags]int32{0, format.TagValueIDTimingLongWindowThrownAgent}}, format.BuiltinMetricMetaTimingErrors)
 	s.statMemoryOverflow = s.CreateBuiltInItemValue(&data_model.Key{Metric: format.BuiltinMetricIDTimingErrors, Tags: [format.MaxTags]int32{0, format.TagValueIDTimingThrownDueToMemory}}, format.BuiltinMetricMetaTimingErrors)
 
-	s.TimingsMapping = s.CreateBuiltInItemValue(&data_model.Key{Metric: format.BuiltinMetricIDAgentTimings, Tags: [format.MaxTags]int32{0, format.TagValueIDAgentTimingGroupPipeline, format.TagValueIDAgentTimingMapping, int32(build.CommitTimestamp())}}, format.BuiltinMetricMetaAgentTimings)
-	s.TimingsMappingSlow = s.CreateBuiltInItemValue(&data_model.Key{Metric: format.BuiltinMetricIDAgentTimings, Tags: [format.MaxTags]int32{0, format.TagValueIDAgentTimingGroupPipeline, format.TagValueIDAgentTimingMappingSlow, int32(build.CommitTimestamp())}}, format.BuiltinMetricMetaAgentTimings)
-	s.TimingsApplyMetric = s.CreateBuiltInItemValue(&data_model.Key{Metric: format.BuiltinMetricIDAgentTimings, Tags: [format.MaxTags]int32{0, format.TagValueIDAgentTimingGroupPipeline, format.TagValueIDAgentTimingApplyMetric, int32(build.CommitTimestamp())}}, format.BuiltinMetricMetaAgentTimings)
-	s.TimingsFlush = s.CreateBuiltInItemValue(&data_model.Key{Metric: format.BuiltinMetricIDAgentTimings, Tags: [format.MaxTags]int32{0, format.TagValueIDAgentTimingGroupPipeline, format.TagValueIDAgentTimingFlush, int32(build.CommitTimestamp())}}, format.BuiltinMetricMetaAgentTimings)
-	s.TimingsPreprocess = s.CreateBuiltInItemValue(&data_model.Key{Metric: format.BuiltinMetricIDAgentTimings, Tags: [format.MaxTags]int32{0, format.TagValueIDAgentTimingGroupPipeline, format.TagValueIDAgentTimingPreprocess, int32(build.CommitTimestamp())}}, format.BuiltinMetricMetaAgentTimings)
-	s.TimingsSendRecent = s.CreateBuiltInItemValue(&data_model.Key{Metric: format.BuiltinMetricIDAgentTimings, Tags: [format.MaxTags]int32{0, format.TagValueIDAgentTimingGroupSend, format.TagValueIDAgentTimingSendRecent, int32(build.CommitTimestamp())}}, format.BuiltinMetricMetaAgentTimings)
-	s.TimingsSendHistoric = s.CreateBuiltInItemValue(&data_model.Key{Metric: format.BuiltinMetricIDAgentTimings, Tags: [format.MaxTags]int32{0, format.TagValueIDAgentTimingGroupSend, format.TagValueIDAgentTimingSendHistoric, int32(build.CommitTimestamp())}}, format.BuiltinMetricMetaAgentTimings)
+	s.TimingsMapping = s.CreateBuiltInItemValue(&data_model.Key{Metric: format.BuiltinMetricIDAgentTimings, Tags: [format.MaxTags]int32{0, format.TagValueIDAgentTimingGroupPipeline, format.TagValueIDAgentTimingMapping, int32(build.CommitTimestamp()), int32(build.CommitTag())}}, format.BuiltinMetricMetaAgentTimings)
+	s.TimingsMappingSlow = s.CreateBuiltInItemValue(&data_model.Key{Metric: format.BuiltinMetricIDAgentTimings, Tags: [format.MaxTags]int32{0, format.TagValueIDAgentTimingGroupPipeline, format.TagValueIDAgentTimingMappingSlow, int32(build.CommitTimestamp()), int32(build.CommitTag())}}, format.BuiltinMetricMetaAgentTimings)
+	s.TimingsApplyMetric = s.CreateBuiltInItemValue(&data_model.Key{Metric: format.BuiltinMetricIDAgentTimings, Tags: [format.MaxTags]int32{0, format.TagValueIDAgentTimingGroupPipeline, format.TagValueIDAgentTimingApplyMetric, int32(build.CommitTimestamp()), int32(build.CommitTag())}}, format.BuiltinMetricMetaAgentTimings)
+	s.TimingsFlush = s.CreateBuiltInItemValue(&data_model.Key{Metric: format.BuiltinMetricIDAgentTimings, Tags: [format.MaxTags]int32{0, format.TagValueIDAgentTimingGroupPipeline, format.TagValueIDAgentTimingFlush, int32(build.CommitTimestamp()), int32(build.CommitTag())}}, format.BuiltinMetricMetaAgentTimings)
+	s.TimingsPreprocess = s.CreateBuiltInItemValue(&data_model.Key{Metric: format.BuiltinMetricIDAgentTimings, Tags: [format.MaxTags]int32{0, format.TagValueIDAgentTimingGroupPipeline, format.TagValueIDAgentTimingPreprocess, int32(build.CommitTimestamp()), int32(build.CommitTag())}}, format.BuiltinMetricMetaAgentTimings)
+	s.TimingsSendRecent = s.CreateBuiltInItemValue(&data_model.Key{Metric: format.BuiltinMetricIDAgentTimings, Tags: [format.MaxTags]int32{0, format.TagValueIDAgentTimingGroupSend, format.TagValueIDAgentTimingSendRecent, int32(build.CommitTimestamp()), int32(build.CommitTag())}}, format.BuiltinMetricMetaAgentTimings)
+	s.TimingsSendHistoric = s.CreateBuiltInItemValue(&data_model.Key{Metric: format.BuiltinMetricIDAgentTimings, Tags: [format.MaxTags]int32{0, format.TagValueIDAgentTimingGroupSend, format.TagValueIDAgentTimingSendHistoric, int32(build.CommitTimestamp()), int32(build.CommitTag())}}, format.BuiltinMetricMetaAgentTimings)
 
 }
 

--- a/internal/agent/agent_shard_replica.go
+++ b/internal/agent/agent_shard_replica.go
@@ -75,7 +75,7 @@ func (s *ShardReplica) sendSourceBucket2Compressed(ctx context.Context, cbd comp
 	args := tlstatshouse.SendSourceBucket2Bytes{
 		Time:           cbd.time,
 		BuildCommit:    []byte(build.Commit()),
-		BuildCommitTs:  s.agent.commitTimestamp,
+		BuildCommitTs:  build.CommitTimestamp(),
 		OriginalSize:   binary.LittleEndian.Uint32(cbd.data),
 		CompressedData: cbd.data[4:],
 	}
@@ -101,7 +101,7 @@ func (s *ShardReplica) sendSourceBucket3Compressed(ctx context.Context, cbd comp
 	args := tlstatshouse.SendSourceBucket3Bytes{
 		Time:           cbd.time,
 		BuildCommit:    []byte(build.Commit()),
-		BuildCommitTs:  s.agent.commitTimestamp,
+		BuildCommitTs:  build.CommitTimestamp(),
 		OriginalSize:   binary.LittleEndian.Uint32(cbd.data),
 		CompressedData: cbd.data[4:],
 	}

--- a/internal/agent/agent_shard_replica.go
+++ b/internal/agent/agent_shard_replica.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
-	"math"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -61,13 +60,6 @@ type ShardReplica struct {
 
 func (s *ShardReplica) FillStats(stats map[string]string) {
 	s.stats.fillStats(stats)
-}
-
-func clampInt32[I int64 | int](v I) int32 {
-	if v < math.MaxInt32 {
-		return int32(v)
-	}
-	return math.MaxInt32
 }
 
 func (s *ShardReplica) sendSourceBucket2Compressed(ctx context.Context, cbd compressedBucketData, historic bool, spare bool, ret *[]byte, shard *Shard) error {

--- a/internal/agent/agent_shard_send.go
+++ b/internal/agent/agent_shard_send.go
@@ -335,24 +335,24 @@ func (s *Shard) sampleBucket(bucket *data_model.MetricsBucket, rnd *rand.Rand) (
 	sampler.Run(remainingBudget)
 	for _, v := range sampler.MetricGroups {
 		// keep bytes
-		key := data_model.Key{Metric: format.BuiltinMetricIDSrcSamplingSizeBytes, Tags: [format.MaxTags]int32{0, s.agent.componentTag, format.TagValueIDSamplingDecisionKeep, v.NamespaceID, v.GroupID, v.MetricID}}
+		key := data_model.Key{Timestamp: bucket.Time, Metric: format.BuiltinMetricIDSrcSamplingSizeBytes, Tags: [format.MaxTags]int32{0, s.agent.componentTag, format.TagValueIDSamplingDecisionKeep, v.NamespaceID, v.GroupID, v.MetricID}}
 		item, _ := bucket.GetOrCreateMultiItem(&key, config.StringTopCapacity, nil)
 		item.Tail.Value.Merge(rnd, &v.SumSizeKeep)
 		// discard bytes
-		key = data_model.Key{Metric: format.BuiltinMetricIDSrcSamplingSizeBytes, Tags: [format.MaxTags]int32{0, s.agent.componentTag, format.TagValueIDSamplingDecisionDiscard, v.NamespaceID, v.GroupID, v.MetricID}}
+		key = data_model.Key{Timestamp: bucket.Time, Metric: format.BuiltinMetricIDSrcSamplingSizeBytes, Tags: [format.MaxTags]int32{0, s.agent.componentTag, format.TagValueIDSamplingDecisionDiscard, v.NamespaceID, v.GroupID, v.MetricID}}
 		item, _ = bucket.GetOrCreateMultiItem(&key, config.StringTopCapacity, nil)
 		item.Tail.Value.Merge(rnd, &v.SumSizeDiscard)
 		// budget
-		key = data_model.Key{Metric: format.BuiltinMetricIDSrcSamplingGroupBudget, Tags: [format.MaxTags]int32{0, s.agent.componentTag, v.NamespaceID, v.GroupID}}
+		key = data_model.Key{Timestamp: bucket.Time, Metric: format.BuiltinMetricIDSrcSamplingGroupBudget, Tags: [format.MaxTags]int32{0, s.agent.componentTag, v.NamespaceID, v.GroupID}}
 		item, _ = bucket.GetOrCreateMultiItem(&key, config.StringTopCapacity, nil)
 		item.Tail.Value.AddValue(v.Budget())
 	}
 	// report budget used
-	budgetKey := data_model.Key{Metric: format.BuiltinMetricIDSrcSamplingBudget, Tags: [format.MaxTags]int32{0, s.agent.componentTag}}
+	budgetKey := data_model.Key{Timestamp: bucket.Time, Metric: format.BuiltinMetricIDSrcSamplingBudget, Tags: [format.MaxTags]int32{0, s.agent.componentTag}}
 	budgetItem, _ := bucket.GetOrCreateMultiItem(&budgetKey, config.StringTopCapacity, nil)
 	budgetItem.Tail.Value.AddValue(float64(remainingBudget))
 	// metric count
-	key := data_model.Key{Metric: format.BuiltinMetricIDSrcSamplingMetricCount, Tags: [format.MaxTags]int32{0, s.agent.componentTag}}
+	key := data_model.Key{Timestamp: bucket.Time, Metric: format.BuiltinMetricIDSrcSamplingMetricCount, Tags: [format.MaxTags]int32{0, s.agent.componentTag}}
 	item, _ := bucket.GetOrCreateMultiItem(&key, config.StringTopCapacity, nil)
 	item.Tail.Value.AddValueCounterHost(rnd, float64(sampler.MetricCount), 1, 0)
 	return sampler.SampleFactors

--- a/internal/aggregator/aggregator.go
+++ b/internal/aggregator/aggregator.go
@@ -318,11 +318,11 @@ func MakeAggregator(dc *pcache.DiskCache, storageDir string, listenAddr string, 
 	}
 	go a.goInternalLog()
 
-	sh2.Run(a.aggregatorHost, a.shardKey, a.replicaKey)
-
-	go func() {
+	go func() { // before sh2.Run because agent will also connect to local aggregator
 		_ = a.server.ListenAndServe("tcp4", listenAddr)
 	}()
+
+	sh2.Run(a.aggregatorHost, a.shardKey, a.replicaKey)
 	return a, nil
 }
 

--- a/internal/aggregator/aggregator_handlers.go
+++ b/internal/aggregator/aggregator_handlers.go
@@ -228,7 +228,7 @@ func (a *Aggregator) handleSendSourceBucketAny(hctx *rpc.HandlerContext, args tl
 	}
 	// opportunistic mapping. We do not map addrStr. To find hosts with hostname not set use internal_log
 
-	if a.configR.DenyOldAgents && uint32(args.BuildCommitTs) < format.LeastAllowedAgentCommitTs {
+	if a.configR.DenyOldAgents && args.BuildCommitTs < format.LeastAllowedAgentCommitTs {
 		key := a.aggKey(nowUnix, format.BuiltinMetricIDAggOutdatedAgents, [16]int32{0, 0, 0, 0, ownerTagId, 0, int32(addrIPV4)})
 		key = key.WithAgentEnvRouteArch(agentEnv, route, buildArch)
 		a.sh2.AddCounterHost(key, 1, hostTagId, format.BuiltinMetricMetaAggOutdatedAgents)
@@ -379,7 +379,7 @@ func (a *Aggregator) handleSendSourceBucketAny(hctx *rpc.HandlerContext, args tl
 					k.Tags[4] = bcTag
 				}
 				if k.Tags[6] == 0 {
-					k.Tags[6] = args.BuildCommitTs
+					k.Tags[6] = int32(args.BuildCommitTs)
 				}
 				if k.Tags[7] == 0 {
 					k.Tags[7] = hostTagId
@@ -475,7 +475,7 @@ func (a *Aggregator) handleSendSourceBucketAny(hctx *rpc.HandlerContext, args tl
 		componentTag = format.TagValueIDComponentAgent
 	}
 	// This cheap version metric is not affected by agent sampling algorithm in contrast with __heartbeat_version
-	getMultiItem((args.Time/60)*60, format.BuiltinMetricIDVersions, [16]int32{0, 0, componentTag, 0, args.BuildCommitTs, bcTag}).MapStringTopBytes(rng, bcStr, 1).AddCounterHost(rng, 1, hostTagId)
+	getMultiItem((args.Time/60)*60, format.BuiltinMetricIDVersions, [16]int32{0, 0, componentTag, 0, int32(args.BuildCommitTs), bcTag}).MapStringTopBytes(rng, bcStr, 1).AddCounterHost(rng, 1, hostTagId)
 
 	for _, v := range bucket.SampleFactors {
 		// We probably wish to stop splitting by aggregator, because this metric is taking already too much space - about 2% of all data

--- a/internal/aggregator/aggregator_handlers.go
+++ b/internal/aggregator/aggregator_handlers.go
@@ -21,7 +21,6 @@ import (
 	"github.com/vkcom/statshouse/internal/data_model/gen2/tlstatshouse"
 	"github.com/vkcom/statshouse/internal/format"
 	"github.com/vkcom/statshouse/internal/vkgo/basictl"
-	"github.com/vkcom/statshouse/internal/vkgo/build"
 	"github.com/vkcom/statshouse/internal/vkgo/rpc"
 )
 
@@ -106,410 +105,104 @@ func (a *Aggregator) handleGetConfig2(_ context.Context, args tlstatshouse.GetCo
 	return a.getConfigResult(), nil
 }
 
+func decompressOriginal(originalSize uint32, compressedData []byte) ([]byte, error) {
+	if int(originalSize) == len(compressedData) {
+		return compressedData, nil
+	}
+	if originalSize > data_model.MaxUncompressedBucketSize {
+		return nil, fmt.Errorf("failed to deserialize compressed statshouse.sourceBucket - uncompressed size %d too big", originalSize)
+	}
+	bucketBytes := make([]byte, int(originalSize))
+	s, err := lz4.UncompressBlock(compressedData, bucketBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deserialize compressed statshouse.sourceBucket: %w", err)
+	}
+	if s != int(originalSize) {
+		return nil, fmt.Errorf("failed to deserialize compressed statshouse.sourceBucket request: expected size %d actual %d", originalSize, s)
+	}
+	return bucketBytes, nil
+}
+
 func (a *Aggregator) handleSendSourceBucket2(_ context.Context, hctx *rpc.HandlerContext) error {
 	var args tlstatshouse.SendSourceBucket2Bytes
 	if _, err := args.Read(hctx.Request); err != nil {
 		return fmt.Errorf("failed to deserialize statshouse.sendSourceBucket2 request: %w", err)
 	}
-	var bucketBytes []byte
-	if int(args.OriginalSize) != len(args.CompressedData) {
-		if args.OriginalSize > data_model.MaxUncompressedBucketSize {
-			return fmt.Errorf("failed to deserialize compressed statshouse.sourceBucket - uncompressed size %d too big", args.OriginalSize)
-		}
-		bucketBytes = make([]byte, int(args.OriginalSize))
-		s, err := lz4.UncompressBlock(args.CompressedData, bucketBytes)
-		if err != nil {
-			return fmt.Errorf("failed to deserialize compressed statshouse.sourceBucket: %w", err)
-		}
-		if s != int(args.OriginalSize) {
-			return fmt.Errorf("failed to deserialize compressed statshouse.sourceBucket request: expected size %d actual %d", args.OriginalSize, s)
-		}
-		// uncomment if you add fields to the TL
-		bucketBytes = append(bucketBytes, 0, 0, 0, 0) // ingestion_status_ok2, TODO - remove when all agent are updated to version 1.0
-	} else {
-		// uncomment if you add fields to the TL
-		args.CompressedData = append(args.CompressedData, 0, 0, 0, 0) // ingestion_status_ok2, TODO - remove when all agent are updated to version 1.0
-		bucketBytes = args.CompressedData
+	bucketBytes, err := decompressOriginal(args.OriginalSize, args.CompressedData)
+	if err != nil {
+		return err
 	}
-	// Uncomment if you change compressed bucket format
-	// tag, _ := basictl.NatPeekTag(readFrom)
-	// if tag == constants.StatshouseSourceBucket {
-	//	_, err = ud.sourceBucket.ReadBoxed(readFrom)
-	//	if err != nil {
-	//		return fmt.Errorf("failed to deserialize statshouse.sourceBucket: %w", err)
-	//	}
-	//	return a.handleClientBucket(ctx, hctx, ud.sendSourceBucket, ud.sourceBucket, rawSize)
-	// }
+	// if you add fields to the TL, just add placeholders here for those agents who do not send them
+	bucketBytes = append(bucketBytes, 0, 0, 0, 0) // ingestion_status_ok2
+
 	var bucket tlstatshouse.SourceBucket2Bytes
 	if _, err := bucket.ReadBoxed(bucketBytes); err != nil {
 		return fmt.Errorf("failed to deserialize statshouse.sourceBucket2: %w", err)
 	}
-	rng := rand.New()
-	now := time.Now()
-	nowUnix := uint32(now.Unix())
-	receiveDelay := now.Sub(time.Unix(int64(args.Time), 0)).Seconds()
-	// All hosts must be valid and non-empty
-	hostTagId := a.tagsMapper.mapOrFlood(now, args.Header.HostName, format.BuiltinMetricNameBudgetHost, false)
-	var owner int32
-	if args.IsSetOwner() {
-		owner = a.tagsMapper.mapOrFlood(now, args.Owner, format.BuiltinMetricNameBudgetOwner, false)
+	err, str := a.handleSendSourceBucketAny(hctx, args, bucket)
+	if rpc.IsHijackedResponse(err) {
+		return err
 	}
-	agentEnv := a.getAgentEnv(args.Header.IsSetAgentEnvStaging0(args.FieldsMask), args.Header.IsSetAgentEnvStaging1(args.FieldsMask))
-	buildArch := format.FilterBuildArch(args.Header.BuildArch)
-	isRouteProxy := args.Header.IsSetIngressProxy(args.FieldsMask)
-	route := int32(format.TagValueIDRouteDirect)
-	if isRouteProxy {
-		route = int32(format.TagValueIDRouteIngressProxy)
+	if err != nil {
+		return err
 	}
-	var bcStr []byte
-	bcTag := int32(0)
-	if format.ValidStringValue(mem.B(args.BuildCommit)) {
-		bcStr = args.BuildCommit
-		bcStrRaw, _ := hex.DecodeString(string(bcStr))
-		if len(bcStrRaw) >= 4 {
-			bcTag = int32(binary.BigEndian.Uint32(bcStrRaw))
-		}
-	}
-	// TODO - if bcTag == 0 || args.BuildCommitTs == 0 { reply with error "agent must be built correctly with commit timestamp and hash"
-
-	addrIPV4, _ := addrIPString(hctx.RemoteAddr())
-	if args.Header.AgentIp[3] != 0 {
-		addrIPV4 = uint32(args.Header.AgentIp[3])
-	}
-	// opportunistic mapping. We do not map addrStr. To find hosts with hostname not set use internal_log
-
-	if a.configR.DenyOldAgents && format.LeastAllowedAgentCommitTs > 0 {
-		// ensure that it's not bigger then aggregator ts in order to write BuiltinMetricIDAggOutdatedAgents metric
-		effectiveLeastAllowedAgentCommitTs := int32(min(format.LeastAllowedAgentCommitTs, build.CommitTimestamp()))
-		if args.BuildCommitTs < effectiveLeastAllowedAgentCommitTs {
-			key := a.aggKey(nowUnix, format.BuiltinMetricIDAggOutdatedAgents, [16]int32{0, 0, 0, 0, owner, 0, int32(addrIPV4)})
-			key = key.WithAgentEnvRouteArch(agentEnv, route, buildArch)
-			a.sh2.AddCounterHost(key, 1, hostTagId, format.BuiltinMetricMetaAggOutdatedAgents)
-			hctx.Response, _ = args.WriteResult(hctx.Response, []byte("agent is too old please update"))
-			return nil
-		}
-	}
-
-	var aggBucket *aggregatorBucket
-	a.mu.Lock()
-	if err := a.checkShardConfiguration(args.Header.ShardReplica, args.Header.ShardReplicaTotal); err != nil {
-		a.mu.Unlock()
-		key := a.aggKey(nowUnix, format.BuiltinMetricIDAutoConfig, [16]int32{0, 0, 0, 0, format.TagValueIDAutoConfigErrorSend, args.Header.ShardReplica, args.Header.ShardReplicaTotal})
-		key = key.WithAgentEnvRouteArch(agentEnv, route, buildArch)
-		a.sh2.AddCounterHost(key, 1, hostTagId, format.BuiltinMetricMetaAutoConfig)
-		return err // TODO - return code so clients will print into log and discard data
-	}
-
-	if a.bucketsToSend == nil {
-		a.mu.Unlock()
-		// We are in shutdown, recentBuckets stopped moving. We must be very careful
-		// to prevent sending agents responses that will make them erase historic data.
-		// Also, if we reply with errors, agents will resend data.
-		// So we've simply chosen to hijack all responses and do not respond at all.
-		return hctx.HijackResponse(aggBucket) // must be under bucket lock
-	}
-
-	oldestTime := a.recentBuckets[0].time
-	newestTime := a.recentBuckets[len(a.recentBuckets)-1].time
-
-	// Each of 3 replicas are responsible for inserting each consecutive second.
-	// If primary replica for the second is unavailable, agent sends bucket to spare replica responsible for the next second, so we must round up here.
-	// Also, old agents send all buckets to each replica.
-	roundedToOurTime := args.Time
-	for roundedToOurTime%3 != uint32(a.replicaKey-1) {
-		roundedToOurTime++
-	}
-
-	if args.IsSetHistoric() {
-		if roundedToOurTime > newestTime {
-			a.mu.Unlock()
-			key := a.aggKey(nowUnix, format.BuiltinMetricIDTimingErrors, [16]int32{0, format.TagValueIDTimingFutureBucketHistoric})
-			key = key.WithAgentEnvRouteArch(agentEnv, route, buildArch)
-			a.sh2.AddValueCounterHost(key, float64(args.Time)-float64(newestTime), 1, hostTagId, format.BuiltinMetricMetaTimingErrors)
-			// We discard, because otherwise clients will flood aggregators with this data
-			hctx.Response, _ = args.WriteResult(hctx.Response, []byte("historic bucket time is too far in the future"))
-			return nil
-		}
-		if oldestTime >= data_model.MaxHistoricWindow && roundedToOurTime < oldestTime-data_model.MaxHistoricWindow {
-			a.mu.Unlock()
-			key := a.aggKey(nowUnix, format.BuiltinMetricIDTimingErrors, [16]int32{0, format.TagValueIDTimingLongWindowThrownAggregator})
-			key = key.WithAgentEnvRouteArch(agentEnv, route, buildArch)
-			a.sh2.AddValueCounterHost(key, float64(newestTime)-float64(args.Time), 1, hostTagId, format.BuiltinMetricMetaTimingErrors)
-			hctx.Response, _ = args.WriteResult(hctx.Response, []byte("Successfully discarded historic bucket beyond historic window"))
-			return nil
-		}
-		if roundedToOurTime < oldestTime {
-			aggBucket = a.historicBuckets[args.Time]
-			if aggBucket == nil {
-				aggBucket = &aggregatorBucket{
-					time:                        args.Time,
-					contributors:                map[*rpc.HandlerContext]struct{}{},
-					contributorsSimulatedErrors: map[*rpc.HandlerContext]struct{}{},
-					historicHosts:               [2][2]map[int32]int64{{map[int32]int64{}, map[int32]int64{}}, {map[int32]int64{}, map[int32]int64{}}},
-				}
-				a.historicBuckets[args.Time] = aggBucket
-			}
-		} else {
-			// If source receives error from recent conveyor quickly, it will come to spare while bucket is still recent
-			// This is useful optimization, because can save half inserts
-			aggBucket = a.recentBuckets[roundedToOurTime-oldestTime]
-		}
-	} else {
-		if roundedToOurTime > newestTime { // AgentShard too far in a future
-			a.mu.Unlock()
-			key := a.aggKey(nowUnix, format.BuiltinMetricIDTimingErrors, [16]int32{0, format.TagValueIDTimingFutureBucketRecent})
-			key = key.WithAgentEnvRouteArch(agentEnv, route, buildArch)
-			a.sh2.AddValueCounterHost(key, float64(args.Time)-float64(newestTime), 1, hostTagId, format.BuiltinMetricMetaTimingErrors)
-			// We discard, because otherwise clients will flood aggregators with this data
-			hctx.Response, _ = args.WriteResult(hctx.Response, []byte("bucket time is too far in the future"))
-			return nil
-		}
-		if roundedToOurTime < oldestTime {
-			a.mu.Unlock()
-			key := a.aggKey(nowUnix, format.BuiltinMetricIDTimingErrors, [16]int32{0, format.TagValueIDTimingLateRecent})
-			key = key.WithAgentEnvRouteArch(agentEnv, route, buildArch)
-			a.sh2.AddValueCounterHost(key, float64(newestTime)-float64(args.Time), 1, hostTagId, format.BuiltinMetricMetaTimingErrors)
-			return &rpc.Error{
-				Code:        data_model.RPCErrorMissedRecentConveyor,
-				Description: "bucket time is too far in the past for recent conveyor",
-			}
-		}
-		aggBucket = a.recentBuckets[roundedToOurTime-oldestTime]
-		if a.config.SimulateRandomErrors > 0 && rng.Float64() < a.config.SimulateRandomErrors { // SimulateRandomErrors > 0 is optimization
-			// repeat lock dance in aggregation code below
-			aggBucket.sendMu.RLock()
-			a.mu.Unlock()
-			defer aggBucket.sendMu.RUnlock()
-			aggBucket.mu.Lock()
-			defer aggBucket.mu.Unlock()
-
-			aggBucket.contributorsSimulatedErrors[hctx] = struct{}{} // must be under bucket lock
-			return hctx.HijackResponse(aggBucket)                    // must be under bucket lock
-		}
-	}
-
-	aggBucket.sendMu.RLock()
-	// This lock order ensures, that if sender gets a.mu.Lock(), then all aggregating clients already have aggBucket.sendMu.RLock()
-	aggBucket.contributorsMetric[bool2int(args.IsSetSpare())][bool2int(isRouteProxy)].AddCounterHost(rng, 1, hostTagId) // protected by a.mu
-	if args.IsSetHistoric() {
-		a.historicHosts[bool2int(args.IsSetSpare())][bool2int(isRouteProxy)][hostTagId]++
-	}
-	a.mu.Unlock()
-	defer aggBucket.sendMu.RUnlock()
-
-	lockedShard := -1
-	var newKeys []*data_model.Key
-	var usedMetrics []int32
-
-	// We do not want to decompress under lock, so we decompress before ifs, then rarely throw away decompressed data.
-
-	conveyor := int32(format.TagValueIDConveyorRecent)
-	if args.IsSetHistoric() {
-		conveyor = format.TagValueIDConveyorHistoric
-	}
-	spare := int32(format.TagValueIDAggregatorOriginal)
-	if args.IsSetSpare() {
-		spare = format.TagValueIDAggregatorSpare
-	}
-
-	for _, item := range bucket.Metrics {
-		k, sID := data_model.KeyFromStatshouseMultiItem(&item, args.Time, newestTime)
-		if k.Metric < 0 && !format.HardwareMetric(k.Metric) {
-			k = k.WithAgentEnvRouteArch(agentEnv, route, buildArch)
-			if k.Metric == format.BuiltinMetricIDAgentHeartbeatVersion {
-				// Remap legacy metric to a new one
-				k.Metric = format.BuiltinMetricIDHeartbeatVersion
-				k.Tags[2] = k.Tags[1]
-				k.Tags[1] = format.TagValueIDComponentAgent
-			}
-			if k.Metric == format.BuiltinMetricIDAgentHeartbeatArgs {
-				// Remap legacy metric to a new one
-				k.Metric = format.BuiltinMetricIDHeartbeatArgs
-				k.Tags[2] = k.Tags[1]
-				k.Tags[1] = format.TagValueIDComponentAgent
-			}
-			if k.Metric == format.BuiltinMetricIDHeartbeatVersion ||
-				k.Metric == format.BuiltinMetricIDHeartbeatArgs {
-				// In case of agent we need to set IP anyway, so set other keys here, not by source
-				// In case of api other tags are already set, so don't overwrite them
-				if k.Tags[4] == 0 {
-					k.Tags[4] = bcTag
-				}
-				if k.Tags[6] == 0 {
-					k.Tags[6] = args.BuildCommitTs
-				}
-				if k.Tags[7] == 0 {
-					k.Tags[7] = hostTagId
-				}
-				// Valid for api as well because it is on the same host as agent
-				k.Tags[8] = int32(addrIPV4)
-				k.Tags[9] = owner
-			}
-			if k.Metric == format.BuiltinMetricIDRPCRequests {
-				k.Tags[7] = hostTagId // agent cannot easily map its own host for now
-			}
-		}
-		s := aggBucket.lockShard(&lockedShard, sID)
-		mi, created := s.GetOrCreateMultiItem(k, data_model.AggregatorStringTopCapacity, nil)
-		mi.MergeWithTLMultiItem(rng, &item, hostTagId)
-		if created {
-			if !args.IsSetSpare() { // Data from spares should not affect cardinality estimations
-				newKeys = append(newKeys, k)
-			}
-			usedMetrics = append(usedMetrics, k.Metric)
-		}
-	}
-	aggBucket.lockShard(&lockedShard, -1)
-
-	aggBucket.mu.Lock()
-
-	if aggBucket.usedMetrics == nil {
-		aggBucket.usedMetrics = map[int32]struct{}{}
-	}
-	for _, m := range usedMetrics {
-		aggBucket.usedMetrics[m] = struct{}{}
-	}
-	if args.IsSetHistoric() {
-		aggBucket.historicHosts[bool2int(args.IsSetSpare())][bool2int(isRouteProxy)][hostTagId]++
-	}
-	aggBucket.contributors[hctx] = struct{}{}   // must be under bucket lock
-	errHijack := hctx.HijackResponse(aggBucket) // must be under bucket lock
-
-	aggBucket.mu.Unlock()
-
-	// newKeys will not be large, if average cardinality is low
-	// we update estimators under sendMu.RLock so that sample factors used for inserting will be already updated
-	a.estimator.UpdateWithKeys(args.Time, newKeys)
-
-	now2 := time.Now()
-	// Write meta metrics. They all simply go to shard 0 independent of their keys.
-	s := aggBucket.lockShard(&lockedShard, 0)
-	getMultiItem := func(t uint32, m int32, keys [16]int32) *data_model.MultiItem {
-		key := a.aggKey(t, m, keys)
-		key = key.WithAgentEnvRouteArch(agentEnv, route, buildArch)
-		mi, _ := s.GetOrCreateMultiItem(key, data_model.AggregatorStringTopCapacity, nil)
-		return mi
-	}
-	getMultiItem(args.Time, format.BuiltinMetricIDAggSizeCompressed, [16]int32{0, 0, 0, 0, conveyor, spare}).Tail.AddValueCounterHost(rng, float64(len(hctx.Request)), 1, hostTagId)
-
-	getMultiItem(args.Time, format.BuiltinMetricIDAggSizeUncompressed, [16]int32{0, 0, 0, 0, conveyor, spare}).Tail.AddValueCounterHost(rng, float64(args.OriginalSize), 1, hostTagId)
-	getMultiItem(args.Time, format.BuiltinMetricIDAggBucketReceiveDelaySec, [16]int32{0, 0, 0, 0, conveyor, spare, format.TagValueIDSecondReal}).Tail.AddValueCounterHost(rng, receiveDelay, 1, hostTagId)
-	getMultiItem(args.Time, format.BuiltinMetricIDAggBucketAggregateTimeSec, [16]int32{0, 0, 0, 0, conveyor, spare}).Tail.AddValueCounterHost(rng, now2.Sub(now).Seconds(), 1, hostTagId)
-	getMultiItem(args.Time, format.BuiltinMetricIDAggAdditionsToEstimator, [16]int32{0, 0, 0, 0, conveyor, spare}).Tail.AddValueCounterHost(rng, float64(len(newKeys)), 1, hostTagId)
-	if bucket.MissedSeconds != 0 { // TODO - remove after all agents upgraded to write this metric with tag format.TagValueIDTimingMissedSecondsAgent
-		getMultiItem(args.Time, format.BuiltinMetricIDTimingErrors, [16]int32{0, format.TagValueIDTimingMissedSeconds}).Tail.AddValueCounterHost(rng, float64(bucket.MissedSeconds), 1, hostTagId)
-	}
-	if args.QueueSizeMemory > 0 {
-		getMultiItem(args.Time, format.BuiltinMetricIDAgentHistoricQueueSize, [16]int32{0, format.TagValueIDHistoricQueueMemory}).Tail.AddValueCounterHost(rng, float64(args.QueueSizeMemory), 1, hostTagId)
-	}
-	if args.QueueSizeMemorySum > 0 {
-		getMultiItem(args.Time, format.BuiltinMetricIDAgentHistoricQueueSizeSum, [16]int32{0, format.TagValueIDHistoricQueueMemory}).Tail.AddValueCounterHost(rng, float64(args.QueueSizeMemorySum), 1, hostTagId)
-	}
-	if args.QueueSizeDiskUnsent > 0 {
-		getMultiItem(args.Time, format.BuiltinMetricIDAgentHistoricQueueSize, [16]int32{0, format.TagValueIDHistoricQueueDiskUnsent}).Tail.AddValueCounterHost(rng, float64(args.QueueSizeDiskUnsent), 1, hostTagId)
-	}
-	queueSizeDiskSent := float64(args.QueueSizeDisk) - float64(args.QueueSizeDiskUnsent)
-	if queueSizeDiskSent > 0 {
-		getMultiItem(args.Time, format.BuiltinMetricIDAgentHistoricQueueSize, [16]int32{0, format.TagValueIDHistoricQueueDiskSent}).Tail.AddValueCounterHost(rng, float64(queueSizeDiskSent), 1, hostTagId)
-	}
-	if args.QueueSizeDiskSumUnsent > 0 {
-		getMultiItem(args.Time, format.BuiltinMetricIDAgentHistoricQueueSizeSum, [16]int32{0, format.TagValueIDHistoricQueueDiskUnsent}).Tail.AddValueCounterHost(rng, float64(args.QueueSizeDiskSumUnsent), 1, hostTagId)
-	}
-	queueSizeDiskSumSent := float64(args.QueueSizeDiskSum) - float64(args.QueueSizeDiskSumUnsent)
-	if queueSizeDiskSumSent > 0 {
-		getMultiItem(args.Time, format.BuiltinMetricIDAgentHistoricQueueSizeSum, [16]int32{0, format.TagValueIDHistoricQueueDiskSent}).Tail.AddValueCounterHost(rng, float64(queueSizeDiskSumSent), 1, hostTagId)
-	}
-
-	componentTag := args.Header.ComponentTag
-	if componentTag != format.TagValueIDComponentAgent && componentTag != format.TagValueIDComponentAggregator &&
-		componentTag != format.TagValueIDComponentIngressProxy && componentTag != format.TagValueIDComponentAPI {
-		// TODO - remove this if after release, because no more agents will send crap here
-		componentTag = format.TagValueIDComponentAgent
-	}
-	// This cheap version metric is not affected by agent sampling algorithm in contrast with __heartbeat_version
-	getMultiItem((args.Time/60)*60, format.BuiltinMetricIDVersions, [16]int32{0, 0, componentTag, 0, args.BuildCommitTs, bcTag}).MapStringTopBytes(rng, bcStr, 1).AddCounterHost(rng, 1, hostTagId)
-
-	for _, v := range bucket.SampleFactors {
-		// We probably wish to stop splitting by aggregator, because this metric is taking already too much space - about 2% of all data
-		// Counter will be +1 for each agent who sent bucket for this second, so millions.
-		getMultiItem(args.Time, format.BuiltinMetricIDAgentSamplingFactor, [16]int32{0, v.Metric}).Tail.AddValueCounterHost(rng, float64(v.Value), 1, hostTagId)
-	}
-
-	ingestionStatus := func(env int32, metricID int32, status int32, value float32) {
-		mi, _ := s.GetOrCreateMultiItem((&data_model.Key{Timestamp: args.Time, Metric: format.BuiltinMetricIDIngestionStatus, Tags: [16]int32{env, metricID, status}}).WithAgentEnvRouteArch(agentEnv, route, buildArch), data_model.AggregatorStringTopCapacity, nil)
-		mi.Tail.AddCounterHost(rng, float64(value), hostTagId)
-	}
-	for _, v := range bucket.IngestionStatusOk {
-		// We do not split by aggregator, because this metric is taking already too much space - about 1% of all data
-		if v.Value > 0 {
-			ingestionStatus(0, v.Metric, format.TagValueIDSrcIngestionStatusOKCached, v.Value)
-		} else {
-			ingestionStatus(0, v.Metric, format.TagValueIDSrcIngestionStatusOKUncached, -v.Value)
-		}
-	}
-	for _, v := range bucket.IngestionStatusOk2 {
-		// We do not split by aggregator, because this metric is taking already too much space - about 1% of all data
-		if v.Value > 0 {
-			ingestionStatus(v.Env, v.Metric, format.TagValueIDSrcIngestionStatusOKCached, v.Value)
-		} else {
-			// clients before release used count < 0 for uncached status and count > 0 for cached
-			// but there is too little uncached statuses for such optimization, and we wanted
-			// to pass tag that caused uncached loading, so we removed this negative value tweak from agents
-			ingestionStatus(v.Env, v.Metric, format.TagValueIDSrcIngestionStatusOKUncached, -v.Value)
-		}
-	}
-	aggBucket.lockShard(&lockedShard, -1)
-	return errHijack
+	hctx.Response, _ = args.WriteResult(hctx.Response, []byte(str))
+	return nil
 }
 
-// TODO: copy-paste from handleSendSourceBucket2 with minor changes, should be refactored
 func (a *Aggregator) handleSendSourceBucket3(_ context.Context, hctx *rpc.HandlerContext) error {
 	var args tlstatshouse.SendSourceBucket3Bytes
 	if _, err := args.Read(hctx.Request); err != nil {
 		return fmt.Errorf("failed to deserialize statshouse.sendSourceBucket3 request: %w", err)
 	}
-	var bucketBytes []byte
-	if int(args.OriginalSize) != len(args.CompressedData) {
-		if args.OriginalSize > data_model.MaxUncompressedBucketSize {
-			return fmt.Errorf("failed to deserialize compressed statshouse.sourceBucket - uncompressed size %d too big", args.OriginalSize)
-		}
-		bucketBytes = make([]byte, int(args.OriginalSize))
-		s, err := lz4.UncompressBlock(args.CompressedData, bucketBytes)
-		if err != nil {
-			return fmt.Errorf("failed to deserialize compressed statshouse.sourceBucket: %w", err)
-		}
-		if s != int(args.OriginalSize) {
-			return fmt.Errorf("failed to deserialize compressed statshouse.sourceBucket request: expected size %d actual %d", args.OriginalSize, s)
-		}
-		// uncomment if you add fields to the TL
-		bucketBytes = append(bucketBytes, 0, 0, 0, 0) // ingestion_status_ok2, TODO - remove when all agent are updated to version 1.0
-	} else {
-		// uncomment if you add fields to the TL
-		args.CompressedData = append(args.CompressedData, 0, 0, 0, 0) // ingestion_status_ok2, TODO - remove when all agent are updated to version 1.0
-		bucketBytes = args.CompressedData
+	bucketBytes, err := decompressOriginal(args.OriginalSize, args.CompressedData)
+	if err != nil {
+		return err
 	}
-	// Uncomment if you change compressed bucket format
-	// tag, _ := basictl.NatPeekTag(readFrom)
-	// if tag == constants.StatshouseSourceBucket {
-	//	_, err = ud.sourceBucket.ReadBoxed(readFrom)
-	//	if err != nil {
-	//		return fmt.Errorf("failed to deserialize statshouse.sourceBucket: %w", err)
-	//	}
-	//	return a.handleClientBucket(ctx, hctx, ud.sendSourceBucket, ud.sourceBucket, rawSize)
-	// }
 	var bucket tlstatshouse.SourceBucket3Bytes
 	if _, err := bucket.ReadBoxed(bucketBytes); err != nil {
-		return fmt.Errorf("failed to deserialize statshouse.sourceBucket2: %w", err)
+		return fmt.Errorf("failed to deserialize statshouse.sourceBucket3: %w", err)
 	}
+	// we should clear all legacy fields mask which can be independently used by SourceBucket3
+	// we leave only common proxy header maskas, spare and historic which are set to the same bits
+	args2 := tlstatshouse.SendSourceBucket2Bytes{
+		FieldsMask:     args.FieldsMask,
+		Header:         args.Header,
+		Time:           args.Time,
+		BuildCommit:    args.BuildCommit,
+		BuildCommitTs:  args.BuildCommitTs,
+		OriginalSize:   args.OriginalSize,
+		CompressedData: args.CompressedData,
+	}
+	bucket2 := tlstatshouse.SourceBucket2Bytes{
+		Metrics:            bucket.Metrics,
+		SampleFactors:      bucket.SampleFactors,
+		IngestionStatusOk2: bucket.IngestionStatusOk2,
+	}
+	err, str := a.handleSendSourceBucketAny(hctx, args2, bucket2)
+	if rpc.IsHijackedResponse(err) {
+		return err
+	}
+	if err != nil {
+		return err
+	}
+	resp := tlstatshouse.SendSourceBucket3ResponseBytes{
+		Error: []byte(str),
+	}
+	hctx.Response, _ = args.WriteResult(hctx.Response, resp)
+	return nil
+}
+
+func (a *Aggregator) handleSendSourceBucketAny(hctx *rpc.HandlerContext, args tlstatshouse.SendSourceBucket2Bytes, bucket tlstatshouse.SourceBucket2Bytes) (error, string) {
 	rng := rand.New()
 	now := time.Now()
 	nowUnix := uint32(now.Unix())
 	receiveDelay := now.Sub(time.Unix(int64(args.Time), 0)).Seconds()
 	// All hosts must be valid and non-empty
 	hostTagId := a.tagsMapper.mapOrFlood(now, args.Header.HostName, format.BuiltinMetricNameBudgetHost, false)
-	var ownerTagId int32
-	if len(args.Header.Owner) > 0 {
-		ownerTagId = a.tagsMapper.mapOrFlood(now, args.Header.Owner, format.BuiltinMetricNameBudgetOwner, false)
+	ownerTagId := a.tagsMapper.mapOrFlood(now, args.Header.Owner, format.BuiltinMetricNameBudgetOwner, false)
+	if ownerTagId == 0 {
+		ownerTagId = a.tagsMapper.mapOrFlood(now, args.Owner, format.BuiltinMetricNameBudgetOwner, false)
 	}
 	agentEnv := a.getAgentEnv(args.Header.IsSetAgentEnvStaging0(args.FieldsMask), args.Header.IsSetAgentEnvStaging1(args.FieldsMask))
 	buildArch := format.FilterBuildArch(args.Header.BuildArch)
@@ -535,17 +228,11 @@ func (a *Aggregator) handleSendSourceBucket3(_ context.Context, hctx *rpc.Handle
 	}
 	// opportunistic mapping. We do not map addrStr. To find hosts with hostname not set use internal_log
 
-	if a.configR.DenyOldAgents && format.LeastAllowedAgentCommitTs > 0 {
-		// ensure that it's not bigger then aggregator ts in order to write BuiltinMetricIDAggOutdatedAgents metric
-		effectiveLeastAllowedAgentCommitTs := int32(min(format.LeastAllowedAgentCommitTs, build.CommitTimestamp()))
-		if args.BuildCommitTs < effectiveLeastAllowedAgentCommitTs {
-			key := a.aggKey(nowUnix, format.BuiltinMetricIDAggOutdatedAgents, [16]int32{0, 0, 0, 0, ownerTagId, 0, int32(addrIPV4)})
-			key = key.WithAgentEnvRouteArch(agentEnv, route, buildArch)
-			a.sh2.AddCounterHost(key, 1, hostTagId, format.BuiltinMetricMetaAggOutdatedAgents)
-			// TODO: send error .StatshouseSendSourceBucket3ResponseBytes []byte("agent is too old please update")
-			hctx.Response, _ = args.WriteResult(hctx.Response, tlstatshouse.SendSourceBucket3ResponseBytes{})
-			return nil
-		}
+	if a.configR.DenyOldAgents && uint32(args.BuildCommitTs) < format.LeastAllowedAgentCommitTs {
+		key := a.aggKey(nowUnix, format.BuiltinMetricIDAggOutdatedAgents, [16]int32{0, 0, 0, 0, ownerTagId, 0, int32(addrIPV4)})
+		key = key.WithAgentEnvRouteArch(agentEnv, route, buildArch)
+		a.sh2.AddCounterHost(key, 1, hostTagId, format.BuiltinMetricMetaAggOutdatedAgents)
+		return nil, "agent is too old please update"
 	}
 
 	var aggBucket *aggregatorBucket
@@ -555,7 +242,7 @@ func (a *Aggregator) handleSendSourceBucket3(_ context.Context, hctx *rpc.Handle
 		key := a.aggKey(nowUnix, format.BuiltinMetricIDAutoConfig, [16]int32{0, 0, 0, 0, format.TagValueIDAutoConfigErrorSend, args.Header.ShardReplica, args.Header.ShardReplicaTotal})
 		key = key.WithAgentEnvRouteArch(agentEnv, route, buildArch)
 		a.sh2.AddCounterHost(key, 1, hostTagId, format.BuiltinMetricMetaAutoConfig)
-		return err // TODO - return code so clients will print into log and discard data
+		return err, "" // TODO - return code so clients will print into log and discard data
 	}
 
 	if a.bucketsToSend == nil {
@@ -564,7 +251,7 @@ func (a *Aggregator) handleSendSourceBucket3(_ context.Context, hctx *rpc.Handle
 		// to prevent sending agents responses that will make them erase historic data.
 		// Also, if we reply with errors, agents will resend data.
 		// So we've simply chosen to hijack all responses and do not respond at all.
-		return hctx.HijackResponse(aggBucket) // must be under bucket lock
+		return hctx.HijackResponse(aggBucket), "" // must be under bucket lock
 	}
 
 	oldestTime := a.recentBuckets[0].time
@@ -585,18 +272,14 @@ func (a *Aggregator) handleSendSourceBucket3(_ context.Context, hctx *rpc.Handle
 			key = key.WithAgentEnvRouteArch(agentEnv, route, buildArch)
 			a.sh2.AddValueCounterHost(key, float64(args.Time)-float64(newestTime), 1, hostTagId, format.BuiltinMetricMetaTimingErrors)
 			// We discard, because otherwise clients will flood aggregators with this data
-			// TODO: send error .StatshouseSendSourceBucket3ResponseBytes []byte("historic bucket time is too far in the future")
-			hctx.Response, _ = args.WriteResult(hctx.Response, tlstatshouse.SendSourceBucket3ResponseBytes{})
-			return nil
+			return nil, "historic bucket time is too far in the future"
 		}
 		if oldestTime >= data_model.MaxHistoricWindow && roundedToOurTime < oldestTime-data_model.MaxHistoricWindow {
 			a.mu.Unlock()
 			key := a.aggKey(nowUnix, format.BuiltinMetricIDTimingErrors, [16]int32{0, format.TagValueIDTimingLongWindowThrownAggregator})
 			key = key.WithAgentEnvRouteArch(agentEnv, route, buildArch)
 			a.sh2.AddValueCounterHost(key, float64(newestTime)-float64(args.Time), 1, hostTagId, format.BuiltinMetricMetaTimingErrors)
-			// TODO: send error .StatshouseSendSourceBucket3ResponseBytes []byte("Successfully discarded historic bucket beyond historic window")
-			hctx.Response, _ = args.WriteResult(hctx.Response, tlstatshouse.SendSourceBucket3ResponseBytes{})
-			return nil
+			return nil, "Successfully discarded historic bucket beyond historic window"
 		}
 		if roundedToOurTime < oldestTime {
 			aggBucket = a.historicBuckets[args.Time]
@@ -621,9 +304,7 @@ func (a *Aggregator) handleSendSourceBucket3(_ context.Context, hctx *rpc.Handle
 			key = key.WithAgentEnvRouteArch(agentEnv, route, buildArch)
 			a.sh2.AddValueCounterHost(key, float64(args.Time)-float64(newestTime), 1, hostTagId, format.BuiltinMetricMetaTimingErrors)
 			// We discard, because otherwise clients will flood aggregators with this data
-			// TODO: send error .StatshouseSendSourceBucket3ResponseBytes []byte("bucket time is too far in the future")
-			hctx.Response, _ = args.WriteResult(hctx.Response, tlstatshouse.SendSourceBucket3ResponseBytes{})
-			return nil
+			return nil, "bucket time is too far in the future"
 		}
 		if roundedToOurTime < oldestTime {
 			a.mu.Unlock()
@@ -633,7 +314,7 @@ func (a *Aggregator) handleSendSourceBucket3(_ context.Context, hctx *rpc.Handle
 			return &rpc.Error{
 				Code:        data_model.RPCErrorMissedRecentConveyor,
 				Description: "bucket time is too far in the past for recent conveyor",
-			}
+			}, ""
 		}
 		aggBucket = a.recentBuckets[roundedToOurTime-oldestTime]
 		if a.config.SimulateRandomErrors > 0 && rng.Float64() < a.config.SimulateRandomErrors { // SimulateRandomErrors > 0 is optimization
@@ -645,7 +326,7 @@ func (a *Aggregator) handleSendSourceBucket3(_ context.Context, hctx *rpc.Handle
 			defer aggBucket.mu.Unlock()
 
 			aggBucket.contributorsSimulatedErrors[hctx] = struct{}{} // must be under bucket lock
-			return hctx.HijackResponse(aggBucket)                    // must be under bucket lock
+			return hctx.HijackResponse(aggBucket), ""                // must be under bucket lock
 		}
 	}
 
@@ -757,6 +438,10 @@ func (a *Aggregator) handleSendSourceBucket3(_ context.Context, hctx *rpc.Handle
 	getMultiItem(args.Time, format.BuiltinMetricIDAggBucketReceiveDelaySec, [16]int32{0, 0, 0, 0, conveyor, spare, format.TagValueIDSecondReal}).Tail.AddValueCounterHost(rng, receiveDelay, 1, hostTagId)
 	getMultiItem(args.Time, format.BuiltinMetricIDAggBucketAggregateTimeSec, [16]int32{0, 0, 0, 0, conveyor, spare}).Tail.AddValueCounterHost(rng, now2.Sub(now).Seconds(), 1, hostTagId)
 	getMultiItem(args.Time, format.BuiltinMetricIDAggAdditionsToEstimator, [16]int32{0, 0, 0, 0, conveyor, spare}).Tail.AddValueCounterHost(rng, float64(len(newKeys)), 1, hostTagId)
+	if bucket.MissedSeconds != 0 { // TODO - remove after all agents upgraded to write this metric with tag format.TagValueIDTimingMissedSecondsAgent
+		getMultiItem(args.Time, format.BuiltinMetricIDTimingErrors, [16]int32{0, format.TagValueIDTimingMissedSeconds}).Tail.AddValueCounterHost(rng, float64(bucket.MissedSeconds), 1, hostTagId)
+	}
+	// TODO - remove all 6 queue metrics below after all agents upgraded to write this metric directly to bucket
 	if args.QueueSizeMemory > 0 {
 		getMultiItem(args.Time, format.BuiltinMetricIDAgentHistoricQueueSize, [16]int32{0, format.TagValueIDHistoricQueueMemory}).Tail.AddValueCounterHost(rng, float64(args.QueueSizeMemory), 1, hostTagId)
 	}
@@ -809,7 +494,7 @@ func (a *Aggregator) handleSendSourceBucket3(_ context.Context, hctx *rpc.Handle
 		}
 	}
 	aggBucket.lockShard(&lockedShard, -1)
-	return errHijack
+	return errHijack, ""
 }
 
 func (a *Aggregator) handleSendKeepAlive2(_ context.Context, hctx *rpc.HandlerContext) error {

--- a/internal/data_model/bucket.go
+++ b/internal/data_model/bucket.go
@@ -61,8 +61,7 @@ type (
 	}
 
 	MetricsBucket struct {
-		Time       uint32
-		Resolution int // for tracking during testing. 0 is merge of all resolutions
+		Time uint32
 
 		MultiItemMap
 	}
@@ -256,6 +255,10 @@ func (b *MetricsBucket) Empty() bool {
 }
 
 func (b *MultiItemMap) GetOrCreateMultiItem(key *Key, stringTopCapacity int, metricInfo *format.MetricMetaValue) (item *MultiItem, created bool) {
+	//if key.Timestamp == 0 { // TODO - remove check before merge to master
+	//	fmt.Printf("key: %v\n", *key)
+	//	panic("timestamp must be always set at this point of conveyor")
+	//}
 	if b.MultiItems == nil {
 		b.MultiItems = make(map[string]*MultiItem)
 	}

--- a/internal/data_model/gen2/internal/statshouse.sendSourceBucket2.go
+++ b/internal/data_model/gen2/internal/statshouse.sendSourceBucket2.go
@@ -22,7 +22,7 @@ type StatshouseSendSourceBucket2 struct {
 	// Spare (TrueType) // Conditional: item.FieldsMask.1
 	BuildCommit            string
 	BuildCommitDate        int32
-	BuildCommitTs          int32
+	BuildCommitTs          uint32
 	QueueSizeDisk          int32
 	QueueSizeMemory        int32
 	QueueSizeDiskSum       int32 // Conditional: item.FieldsMask.2
@@ -165,7 +165,7 @@ func (item *StatshouseSendSourceBucket2) Read(w []byte) (_ []byte, err error) {
 	if w, err = basictl.IntRead(w, &item.BuildCommitDate); err != nil {
 		return w, err
 	}
-	if w, err = basictl.IntRead(w, &item.BuildCommitTs); err != nil {
+	if w, err = basictl.NatRead(w, &item.BuildCommitTs); err != nil {
 		return w, err
 	}
 	if w, err = basictl.IntRead(w, &item.QueueSizeDisk); err != nil {
@@ -232,7 +232,7 @@ func (item *StatshouseSendSourceBucket2) Write(w []byte) []byte {
 	w = basictl.NatWrite(w, item.Time)
 	w = basictl.StringWrite(w, item.BuildCommit)
 	w = basictl.IntWrite(w, item.BuildCommitDate)
-	w = basictl.IntWrite(w, item.BuildCommitTs)
+	w = basictl.NatWrite(w, item.BuildCommitTs)
 	w = basictl.IntWrite(w, item.QueueSizeDisk)
 	w = basictl.IntWrite(w, item.QueueSizeMemory)
 	if item.FieldsMask&(1<<2) != 0 {
@@ -432,7 +432,7 @@ func (item *StatshouseSendSourceBucket2) ReadJSON(legacyTypeNames bool, in *basi
 				if propBuildCommitTsPresented {
 					return ErrorInvalidJSONWithDuplicatingKeys("statshouse.sendSourceBucket2", "build_commit_ts")
 				}
-				if err := Json2ReadInt32(in, &item.BuildCommitTs); err != nil {
+				if err := Json2ReadUint32(in, &item.BuildCommitTs); err != nil {
 					return err
 				}
 				propBuildCommitTsPresented = true
@@ -668,7 +668,7 @@ func (item *StatshouseSendSourceBucket2) WriteJSONOpt(newTypeNames bool, short b
 	backupIndexBuildCommitTs := len(w)
 	w = basictl.JSONAddCommaIfNeeded(w)
 	w = append(w, `"build_commit_ts":`...)
-	w = basictl.JSONWriteInt32(w, item.BuildCommitTs)
+	w = basictl.JSONWriteUint32(w, item.BuildCommitTs)
 	if (item.BuildCommitTs != 0) == false {
 		w = w[:backupIndexBuildCommitTs]
 	}
@@ -748,7 +748,7 @@ type StatshouseSendSourceBucket2Bytes struct {
 	// Spare (TrueType) // Conditional: item.FieldsMask.1
 	BuildCommit            []byte
 	BuildCommitDate        int32
-	BuildCommitTs          int32
+	BuildCommitTs          uint32
 	QueueSizeDisk          int32
 	QueueSizeMemory        int32
 	QueueSizeDiskSum       int32 // Conditional: item.FieldsMask.2
@@ -891,7 +891,7 @@ func (item *StatshouseSendSourceBucket2Bytes) Read(w []byte) (_ []byte, err erro
 	if w, err = basictl.IntRead(w, &item.BuildCommitDate); err != nil {
 		return w, err
 	}
-	if w, err = basictl.IntRead(w, &item.BuildCommitTs); err != nil {
+	if w, err = basictl.NatRead(w, &item.BuildCommitTs); err != nil {
 		return w, err
 	}
 	if w, err = basictl.IntRead(w, &item.QueueSizeDisk); err != nil {
@@ -958,7 +958,7 @@ func (item *StatshouseSendSourceBucket2Bytes) Write(w []byte) []byte {
 	w = basictl.NatWrite(w, item.Time)
 	w = basictl.StringWriteBytes(w, item.BuildCommit)
 	w = basictl.IntWrite(w, item.BuildCommitDate)
-	w = basictl.IntWrite(w, item.BuildCommitTs)
+	w = basictl.NatWrite(w, item.BuildCommitTs)
 	w = basictl.IntWrite(w, item.QueueSizeDisk)
 	w = basictl.IntWrite(w, item.QueueSizeMemory)
 	if item.FieldsMask&(1<<2) != 0 {
@@ -1158,7 +1158,7 @@ func (item *StatshouseSendSourceBucket2Bytes) ReadJSON(legacyTypeNames bool, in 
 				if propBuildCommitTsPresented {
 					return ErrorInvalidJSONWithDuplicatingKeys("statshouse.sendSourceBucket2", "build_commit_ts")
 				}
-				if err := Json2ReadInt32(in, &item.BuildCommitTs); err != nil {
+				if err := Json2ReadUint32(in, &item.BuildCommitTs); err != nil {
 					return err
 				}
 				propBuildCommitTsPresented = true
@@ -1394,7 +1394,7 @@ func (item *StatshouseSendSourceBucket2Bytes) WriteJSONOpt(newTypeNames bool, sh
 	backupIndexBuildCommitTs := len(w)
 	w = basictl.JSONAddCommaIfNeeded(w)
 	w = append(w, `"build_commit_ts":`...)
-	w = basictl.JSONWriteInt32(w, item.BuildCommitTs)
+	w = basictl.JSONWriteUint32(w, item.BuildCommitTs)
 	if (item.BuildCommitTs != 0) == false {
 		w = w[:backupIndexBuildCommitTs]
 	}

--- a/internal/data_model/gen2/internal/statshouse.sendSourceBucket3.go
+++ b/internal/data_model/gen2/internal/statshouse.sendSourceBucket3.go
@@ -20,7 +20,7 @@ type StatshouseSendSourceBucket3 struct {
 	// Historic (TrueType) // Conditional: item.FieldsMask.0
 	// Spare (TrueType) // Conditional: item.FieldsMask.1
 	BuildCommit    string
-	BuildCommitTs  int32
+	BuildCommitTs  uint32
 	OriginalSize   uint32
 	CompressedData string
 }
@@ -69,7 +69,7 @@ func (item *StatshouseSendSourceBucket3) Read(w []byte) (_ []byte, err error) {
 	if w, err = basictl.StringRead(w, &item.BuildCommit); err != nil {
 		return w, err
 	}
-	if w, err = basictl.IntRead(w, &item.BuildCommitTs); err != nil {
+	if w, err = basictl.NatRead(w, &item.BuildCommitTs); err != nil {
 		return w, err
 	}
 	if w, err = basictl.NatRead(w, &item.OriginalSize); err != nil {
@@ -88,7 +88,7 @@ func (item *StatshouseSendSourceBucket3) Write(w []byte) []byte {
 	w = item.Header.Write(w, item.FieldsMask)
 	w = basictl.NatWrite(w, item.Time)
 	w = basictl.StringWrite(w, item.BuildCommit)
-	w = basictl.IntWrite(w, item.BuildCommitTs)
+	w = basictl.NatWrite(w, item.BuildCommitTs)
 	w = basictl.NatWrite(w, item.OriginalSize)
 	w = basictl.StringWrite(w, item.CompressedData)
 	return w
@@ -242,7 +242,7 @@ func (item *StatshouseSendSourceBucket3) ReadJSON(legacyTypeNames bool, in *basi
 				if propBuildCommitTsPresented {
 					return ErrorInvalidJSONWithDuplicatingKeys("statshouse.sendSourceBucket3", "build_commit_ts")
 				}
-				if err := Json2ReadInt32(in, &item.BuildCommitTs); err != nil {
+				if err := Json2ReadUint32(in, &item.BuildCommitTs); err != nil {
 					return err
 				}
 				propBuildCommitTsPresented = true
@@ -365,7 +365,7 @@ func (item *StatshouseSendSourceBucket3) WriteJSONOpt(newTypeNames bool, short b
 	backupIndexBuildCommitTs := len(w)
 	w = basictl.JSONAddCommaIfNeeded(w)
 	w = append(w, `"build_commit_ts":`...)
-	w = basictl.JSONWriteInt32(w, item.BuildCommitTs)
+	w = basictl.JSONWriteUint32(w, item.BuildCommitTs)
 	if (item.BuildCommitTs != 0) == false {
 		w = w[:backupIndexBuildCommitTs]
 	}
@@ -404,7 +404,7 @@ type StatshouseSendSourceBucket3Bytes struct {
 	// Historic (TrueType) // Conditional: item.FieldsMask.0
 	// Spare (TrueType) // Conditional: item.FieldsMask.1
 	BuildCommit    []byte
-	BuildCommitTs  int32
+	BuildCommitTs  uint32
 	OriginalSize   uint32
 	CompressedData []byte
 }
@@ -453,7 +453,7 @@ func (item *StatshouseSendSourceBucket3Bytes) Read(w []byte) (_ []byte, err erro
 	if w, err = basictl.StringReadBytes(w, &item.BuildCommit); err != nil {
 		return w, err
 	}
-	if w, err = basictl.IntRead(w, &item.BuildCommitTs); err != nil {
+	if w, err = basictl.NatRead(w, &item.BuildCommitTs); err != nil {
 		return w, err
 	}
 	if w, err = basictl.NatRead(w, &item.OriginalSize); err != nil {
@@ -472,7 +472,7 @@ func (item *StatshouseSendSourceBucket3Bytes) Write(w []byte) []byte {
 	w = item.Header.Write(w, item.FieldsMask)
 	w = basictl.NatWrite(w, item.Time)
 	w = basictl.StringWriteBytes(w, item.BuildCommit)
-	w = basictl.IntWrite(w, item.BuildCommitTs)
+	w = basictl.NatWrite(w, item.BuildCommitTs)
 	w = basictl.NatWrite(w, item.OriginalSize)
 	w = basictl.StringWriteBytes(w, item.CompressedData)
 	return w
@@ -626,7 +626,7 @@ func (item *StatshouseSendSourceBucket3Bytes) ReadJSON(legacyTypeNames bool, in 
 				if propBuildCommitTsPresented {
 					return ErrorInvalidJSONWithDuplicatingKeys("statshouse.sendSourceBucket3", "build_commit_ts")
 				}
-				if err := Json2ReadInt32(in, &item.BuildCommitTs); err != nil {
+				if err := Json2ReadUint32(in, &item.BuildCommitTs); err != nil {
 					return err
 				}
 				propBuildCommitTsPresented = true
@@ -749,7 +749,7 @@ func (item *StatshouseSendSourceBucket3Bytes) WriteJSONOpt(newTypeNames bool, sh
 	backupIndexBuildCommitTs := len(w)
 	w = basictl.JSONAddCommaIfNeeded(w)
 	w = append(w, `"build_commit_ts":`...)
-	w = basictl.JSONWriteInt32(w, item.BuildCommitTs)
+	w = basictl.JSONWriteUint32(w, item.BuildCommitTs)
 	if (item.BuildCommitTs != 0) == false {
 		w = w[:backupIndexBuildCommitTs]
 	}

--- a/internal/data_model/gen2/internal/statshouse.sendSourceBucket3.go
+++ b/internal/data_model/gen2/internal/statshouse.sendSourceBucket3.go
@@ -19,16 +19,10 @@ type StatshouseSendSourceBucket3 struct {
 	Time       uint32
 	// Historic (TrueType) // Conditional: item.FieldsMask.0
 	// Spare (TrueType) // Conditional: item.FieldsMask.1
-	BuildCommit            string
-	BuildCommitTs          int32
-	QueueSizeDisk          int32
-	QueueSizeMemory        int32
-	QueueSizeDiskSum       int32
-	QueueSizeMemorySum     int32
-	QueueSizeDiskUnsent    int32
-	QueueSizeDiskSumUnsent int32
-	OriginalSize           uint32
-	CompressedData         string
+	BuildCommit    string
+	BuildCommitTs  int32
+	OriginalSize   uint32
+	CompressedData string
 }
 
 func (StatshouseSendSourceBucket3) TLName() string { return "statshouse.sendSourceBucket3" }
@@ -58,12 +52,6 @@ func (item *StatshouseSendSourceBucket3) Reset() {
 	item.Time = 0
 	item.BuildCommit = ""
 	item.BuildCommitTs = 0
-	item.QueueSizeDisk = 0
-	item.QueueSizeMemory = 0
-	item.QueueSizeDiskSum = 0
-	item.QueueSizeMemorySum = 0
-	item.QueueSizeDiskUnsent = 0
-	item.QueueSizeDiskSumUnsent = 0
 	item.OriginalSize = 0
 	item.CompressedData = ""
 }
@@ -84,24 +72,6 @@ func (item *StatshouseSendSourceBucket3) Read(w []byte) (_ []byte, err error) {
 	if w, err = basictl.IntRead(w, &item.BuildCommitTs); err != nil {
 		return w, err
 	}
-	if w, err = basictl.IntRead(w, &item.QueueSizeDisk); err != nil {
-		return w, err
-	}
-	if w, err = basictl.IntRead(w, &item.QueueSizeMemory); err != nil {
-		return w, err
-	}
-	if w, err = basictl.IntRead(w, &item.QueueSizeDiskSum); err != nil {
-		return w, err
-	}
-	if w, err = basictl.IntRead(w, &item.QueueSizeMemorySum); err != nil {
-		return w, err
-	}
-	if w, err = basictl.IntRead(w, &item.QueueSizeDiskUnsent); err != nil {
-		return w, err
-	}
-	if w, err = basictl.IntRead(w, &item.QueueSizeDiskSumUnsent); err != nil {
-		return w, err
-	}
 	if w, err = basictl.NatRead(w, &item.OriginalSize); err != nil {
 		return w, err
 	}
@@ -119,12 +89,6 @@ func (item *StatshouseSendSourceBucket3) Write(w []byte) []byte {
 	w = basictl.NatWrite(w, item.Time)
 	w = basictl.StringWrite(w, item.BuildCommit)
 	w = basictl.IntWrite(w, item.BuildCommitTs)
-	w = basictl.IntWrite(w, item.QueueSizeDisk)
-	w = basictl.IntWrite(w, item.QueueSizeMemory)
-	w = basictl.IntWrite(w, item.QueueSizeDiskSum)
-	w = basictl.IntWrite(w, item.QueueSizeMemorySum)
-	w = basictl.IntWrite(w, item.QueueSizeDiskUnsent)
-	w = basictl.IntWrite(w, item.QueueSizeDiskSumUnsent)
 	w = basictl.NatWrite(w, item.OriginalSize)
 	w = basictl.StringWrite(w, item.CompressedData)
 	return w
@@ -214,12 +178,6 @@ func (item *StatshouseSendSourceBucket3) ReadJSON(legacyTypeNames bool, in *basi
 	var trueTypeSpareValue bool
 	var propBuildCommitPresented bool
 	var propBuildCommitTsPresented bool
-	var propQueueSizeDiskPresented bool
-	var propQueueSizeMemoryPresented bool
-	var propQueueSizeDiskSumPresented bool
-	var propQueueSizeMemorySumPresented bool
-	var propQueueSizeDiskUnsentPresented bool
-	var propQueueSizeDiskSumUnsentPresented bool
 	var propOriginalSizePresented bool
 	var propCompressedDataPresented bool
 
@@ -288,54 +246,6 @@ func (item *StatshouseSendSourceBucket3) ReadJSON(legacyTypeNames bool, in *basi
 					return err
 				}
 				propBuildCommitTsPresented = true
-			case "queue_size_disk":
-				if propQueueSizeDiskPresented {
-					return ErrorInvalidJSONWithDuplicatingKeys("statshouse.sendSourceBucket3", "queue_size_disk")
-				}
-				if err := Json2ReadInt32(in, &item.QueueSizeDisk); err != nil {
-					return err
-				}
-				propQueueSizeDiskPresented = true
-			case "queue_size_memory":
-				if propQueueSizeMemoryPresented {
-					return ErrorInvalidJSONWithDuplicatingKeys("statshouse.sendSourceBucket3", "queue_size_memory")
-				}
-				if err := Json2ReadInt32(in, &item.QueueSizeMemory); err != nil {
-					return err
-				}
-				propQueueSizeMemoryPresented = true
-			case "queue_size_disk_sum":
-				if propQueueSizeDiskSumPresented {
-					return ErrorInvalidJSONWithDuplicatingKeys("statshouse.sendSourceBucket3", "queue_size_disk_sum")
-				}
-				if err := Json2ReadInt32(in, &item.QueueSizeDiskSum); err != nil {
-					return err
-				}
-				propQueueSizeDiskSumPresented = true
-			case "queue_size_memory_sum":
-				if propQueueSizeMemorySumPresented {
-					return ErrorInvalidJSONWithDuplicatingKeys("statshouse.sendSourceBucket3", "queue_size_memory_sum")
-				}
-				if err := Json2ReadInt32(in, &item.QueueSizeMemorySum); err != nil {
-					return err
-				}
-				propQueueSizeMemorySumPresented = true
-			case "queue_size_disk_unsent":
-				if propQueueSizeDiskUnsentPresented {
-					return ErrorInvalidJSONWithDuplicatingKeys("statshouse.sendSourceBucket3", "queue_size_disk_unsent")
-				}
-				if err := Json2ReadInt32(in, &item.QueueSizeDiskUnsent); err != nil {
-					return err
-				}
-				propQueueSizeDiskUnsentPresented = true
-			case "queue_size_disk_sum_unsent":
-				if propQueueSizeDiskSumUnsentPresented {
-					return ErrorInvalidJSONWithDuplicatingKeys("statshouse.sendSourceBucket3", "queue_size_disk_sum_unsent")
-				}
-				if err := Json2ReadInt32(in, &item.QueueSizeDiskSumUnsent); err != nil {
-					return err
-				}
-				propQueueSizeDiskSumUnsentPresented = true
 			case "original_size":
 				if propOriginalSizePresented {
 					return ErrorInvalidJSONWithDuplicatingKeys("statshouse.sendSourceBucket3", "original_size")
@@ -373,24 +283,6 @@ func (item *StatshouseSendSourceBucket3) ReadJSON(legacyTypeNames bool, in *basi
 	}
 	if !propBuildCommitTsPresented {
 		item.BuildCommitTs = 0
-	}
-	if !propQueueSizeDiskPresented {
-		item.QueueSizeDisk = 0
-	}
-	if !propQueueSizeMemoryPresented {
-		item.QueueSizeMemory = 0
-	}
-	if !propQueueSizeDiskSumPresented {
-		item.QueueSizeDiskSum = 0
-	}
-	if !propQueueSizeMemorySumPresented {
-		item.QueueSizeMemorySum = 0
-	}
-	if !propQueueSizeDiskUnsentPresented {
-		item.QueueSizeDiskUnsent = 0
-	}
-	if !propQueueSizeDiskSumUnsentPresented {
-		item.QueueSizeDiskSumUnsent = 0
 	}
 	if !propOriginalSizePresented {
 		item.OriginalSize = 0
@@ -477,48 +369,6 @@ func (item *StatshouseSendSourceBucket3) WriteJSONOpt(newTypeNames bool, short b
 	if (item.BuildCommitTs != 0) == false {
 		w = w[:backupIndexBuildCommitTs]
 	}
-	backupIndexQueueSizeDisk := len(w)
-	w = basictl.JSONAddCommaIfNeeded(w)
-	w = append(w, `"queue_size_disk":`...)
-	w = basictl.JSONWriteInt32(w, item.QueueSizeDisk)
-	if (item.QueueSizeDisk != 0) == false {
-		w = w[:backupIndexQueueSizeDisk]
-	}
-	backupIndexQueueSizeMemory := len(w)
-	w = basictl.JSONAddCommaIfNeeded(w)
-	w = append(w, `"queue_size_memory":`...)
-	w = basictl.JSONWriteInt32(w, item.QueueSizeMemory)
-	if (item.QueueSizeMemory != 0) == false {
-		w = w[:backupIndexQueueSizeMemory]
-	}
-	backupIndexQueueSizeDiskSum := len(w)
-	w = basictl.JSONAddCommaIfNeeded(w)
-	w = append(w, `"queue_size_disk_sum":`...)
-	w = basictl.JSONWriteInt32(w, item.QueueSizeDiskSum)
-	if (item.QueueSizeDiskSum != 0) == false {
-		w = w[:backupIndexQueueSizeDiskSum]
-	}
-	backupIndexQueueSizeMemorySum := len(w)
-	w = basictl.JSONAddCommaIfNeeded(w)
-	w = append(w, `"queue_size_memory_sum":`...)
-	w = basictl.JSONWriteInt32(w, item.QueueSizeMemorySum)
-	if (item.QueueSizeMemorySum != 0) == false {
-		w = w[:backupIndexQueueSizeMemorySum]
-	}
-	backupIndexQueueSizeDiskUnsent := len(w)
-	w = basictl.JSONAddCommaIfNeeded(w)
-	w = append(w, `"queue_size_disk_unsent":`...)
-	w = basictl.JSONWriteInt32(w, item.QueueSizeDiskUnsent)
-	if (item.QueueSizeDiskUnsent != 0) == false {
-		w = w[:backupIndexQueueSizeDiskUnsent]
-	}
-	backupIndexQueueSizeDiskSumUnsent := len(w)
-	w = basictl.JSONAddCommaIfNeeded(w)
-	w = append(w, `"queue_size_disk_sum_unsent":`...)
-	w = basictl.JSONWriteInt32(w, item.QueueSizeDiskSumUnsent)
-	if (item.QueueSizeDiskSumUnsent != 0) == false {
-		w = w[:backupIndexQueueSizeDiskSumUnsent]
-	}
 	backupIndexOriginalSize := len(w)
 	w = basictl.JSONAddCommaIfNeeded(w)
 	w = append(w, `"original_size":`...)
@@ -553,16 +403,10 @@ type StatshouseSendSourceBucket3Bytes struct {
 	Time       uint32
 	// Historic (TrueType) // Conditional: item.FieldsMask.0
 	// Spare (TrueType) // Conditional: item.FieldsMask.1
-	BuildCommit            []byte
-	BuildCommitTs          int32
-	QueueSizeDisk          int32
-	QueueSizeMemory        int32
-	QueueSizeDiskSum       int32
-	QueueSizeMemorySum     int32
-	QueueSizeDiskUnsent    int32
-	QueueSizeDiskSumUnsent int32
-	OriginalSize           uint32
-	CompressedData         []byte
+	BuildCommit    []byte
+	BuildCommitTs  int32
+	OriginalSize   uint32
+	CompressedData []byte
 }
 
 func (StatshouseSendSourceBucket3Bytes) TLName() string { return "statshouse.sendSourceBucket3" }
@@ -592,12 +436,6 @@ func (item *StatshouseSendSourceBucket3Bytes) Reset() {
 	item.Time = 0
 	item.BuildCommit = item.BuildCommit[:0]
 	item.BuildCommitTs = 0
-	item.QueueSizeDisk = 0
-	item.QueueSizeMemory = 0
-	item.QueueSizeDiskSum = 0
-	item.QueueSizeMemorySum = 0
-	item.QueueSizeDiskUnsent = 0
-	item.QueueSizeDiskSumUnsent = 0
 	item.OriginalSize = 0
 	item.CompressedData = item.CompressedData[:0]
 }
@@ -618,24 +456,6 @@ func (item *StatshouseSendSourceBucket3Bytes) Read(w []byte) (_ []byte, err erro
 	if w, err = basictl.IntRead(w, &item.BuildCommitTs); err != nil {
 		return w, err
 	}
-	if w, err = basictl.IntRead(w, &item.QueueSizeDisk); err != nil {
-		return w, err
-	}
-	if w, err = basictl.IntRead(w, &item.QueueSizeMemory); err != nil {
-		return w, err
-	}
-	if w, err = basictl.IntRead(w, &item.QueueSizeDiskSum); err != nil {
-		return w, err
-	}
-	if w, err = basictl.IntRead(w, &item.QueueSizeMemorySum); err != nil {
-		return w, err
-	}
-	if w, err = basictl.IntRead(w, &item.QueueSizeDiskUnsent); err != nil {
-		return w, err
-	}
-	if w, err = basictl.IntRead(w, &item.QueueSizeDiskSumUnsent); err != nil {
-		return w, err
-	}
 	if w, err = basictl.NatRead(w, &item.OriginalSize); err != nil {
 		return w, err
 	}
@@ -653,12 +473,6 @@ func (item *StatshouseSendSourceBucket3Bytes) Write(w []byte) []byte {
 	w = basictl.NatWrite(w, item.Time)
 	w = basictl.StringWriteBytes(w, item.BuildCommit)
 	w = basictl.IntWrite(w, item.BuildCommitTs)
-	w = basictl.IntWrite(w, item.QueueSizeDisk)
-	w = basictl.IntWrite(w, item.QueueSizeMemory)
-	w = basictl.IntWrite(w, item.QueueSizeDiskSum)
-	w = basictl.IntWrite(w, item.QueueSizeMemorySum)
-	w = basictl.IntWrite(w, item.QueueSizeDiskUnsent)
-	w = basictl.IntWrite(w, item.QueueSizeDiskSumUnsent)
 	w = basictl.NatWrite(w, item.OriginalSize)
 	w = basictl.StringWriteBytes(w, item.CompressedData)
 	return w
@@ -748,12 +562,6 @@ func (item *StatshouseSendSourceBucket3Bytes) ReadJSON(legacyTypeNames bool, in 
 	var trueTypeSpareValue bool
 	var propBuildCommitPresented bool
 	var propBuildCommitTsPresented bool
-	var propQueueSizeDiskPresented bool
-	var propQueueSizeMemoryPresented bool
-	var propQueueSizeDiskSumPresented bool
-	var propQueueSizeMemorySumPresented bool
-	var propQueueSizeDiskUnsentPresented bool
-	var propQueueSizeDiskSumUnsentPresented bool
 	var propOriginalSizePresented bool
 	var propCompressedDataPresented bool
 
@@ -822,54 +630,6 @@ func (item *StatshouseSendSourceBucket3Bytes) ReadJSON(legacyTypeNames bool, in 
 					return err
 				}
 				propBuildCommitTsPresented = true
-			case "queue_size_disk":
-				if propQueueSizeDiskPresented {
-					return ErrorInvalidJSONWithDuplicatingKeys("statshouse.sendSourceBucket3", "queue_size_disk")
-				}
-				if err := Json2ReadInt32(in, &item.QueueSizeDisk); err != nil {
-					return err
-				}
-				propQueueSizeDiskPresented = true
-			case "queue_size_memory":
-				if propQueueSizeMemoryPresented {
-					return ErrorInvalidJSONWithDuplicatingKeys("statshouse.sendSourceBucket3", "queue_size_memory")
-				}
-				if err := Json2ReadInt32(in, &item.QueueSizeMemory); err != nil {
-					return err
-				}
-				propQueueSizeMemoryPresented = true
-			case "queue_size_disk_sum":
-				if propQueueSizeDiskSumPresented {
-					return ErrorInvalidJSONWithDuplicatingKeys("statshouse.sendSourceBucket3", "queue_size_disk_sum")
-				}
-				if err := Json2ReadInt32(in, &item.QueueSizeDiskSum); err != nil {
-					return err
-				}
-				propQueueSizeDiskSumPresented = true
-			case "queue_size_memory_sum":
-				if propQueueSizeMemorySumPresented {
-					return ErrorInvalidJSONWithDuplicatingKeys("statshouse.sendSourceBucket3", "queue_size_memory_sum")
-				}
-				if err := Json2ReadInt32(in, &item.QueueSizeMemorySum); err != nil {
-					return err
-				}
-				propQueueSizeMemorySumPresented = true
-			case "queue_size_disk_unsent":
-				if propQueueSizeDiskUnsentPresented {
-					return ErrorInvalidJSONWithDuplicatingKeys("statshouse.sendSourceBucket3", "queue_size_disk_unsent")
-				}
-				if err := Json2ReadInt32(in, &item.QueueSizeDiskUnsent); err != nil {
-					return err
-				}
-				propQueueSizeDiskUnsentPresented = true
-			case "queue_size_disk_sum_unsent":
-				if propQueueSizeDiskSumUnsentPresented {
-					return ErrorInvalidJSONWithDuplicatingKeys("statshouse.sendSourceBucket3", "queue_size_disk_sum_unsent")
-				}
-				if err := Json2ReadInt32(in, &item.QueueSizeDiskSumUnsent); err != nil {
-					return err
-				}
-				propQueueSizeDiskSumUnsentPresented = true
 			case "original_size":
 				if propOriginalSizePresented {
 					return ErrorInvalidJSONWithDuplicatingKeys("statshouse.sendSourceBucket3", "original_size")
@@ -907,24 +667,6 @@ func (item *StatshouseSendSourceBucket3Bytes) ReadJSON(legacyTypeNames bool, in 
 	}
 	if !propBuildCommitTsPresented {
 		item.BuildCommitTs = 0
-	}
-	if !propQueueSizeDiskPresented {
-		item.QueueSizeDisk = 0
-	}
-	if !propQueueSizeMemoryPresented {
-		item.QueueSizeMemory = 0
-	}
-	if !propQueueSizeDiskSumPresented {
-		item.QueueSizeDiskSum = 0
-	}
-	if !propQueueSizeMemorySumPresented {
-		item.QueueSizeMemorySum = 0
-	}
-	if !propQueueSizeDiskUnsentPresented {
-		item.QueueSizeDiskUnsent = 0
-	}
-	if !propQueueSizeDiskSumUnsentPresented {
-		item.QueueSizeDiskSumUnsent = 0
 	}
 	if !propOriginalSizePresented {
 		item.OriginalSize = 0
@@ -1010,48 +752,6 @@ func (item *StatshouseSendSourceBucket3Bytes) WriteJSONOpt(newTypeNames bool, sh
 	w = basictl.JSONWriteInt32(w, item.BuildCommitTs)
 	if (item.BuildCommitTs != 0) == false {
 		w = w[:backupIndexBuildCommitTs]
-	}
-	backupIndexQueueSizeDisk := len(w)
-	w = basictl.JSONAddCommaIfNeeded(w)
-	w = append(w, `"queue_size_disk":`...)
-	w = basictl.JSONWriteInt32(w, item.QueueSizeDisk)
-	if (item.QueueSizeDisk != 0) == false {
-		w = w[:backupIndexQueueSizeDisk]
-	}
-	backupIndexQueueSizeMemory := len(w)
-	w = basictl.JSONAddCommaIfNeeded(w)
-	w = append(w, `"queue_size_memory":`...)
-	w = basictl.JSONWriteInt32(w, item.QueueSizeMemory)
-	if (item.QueueSizeMemory != 0) == false {
-		w = w[:backupIndexQueueSizeMemory]
-	}
-	backupIndexQueueSizeDiskSum := len(w)
-	w = basictl.JSONAddCommaIfNeeded(w)
-	w = append(w, `"queue_size_disk_sum":`...)
-	w = basictl.JSONWriteInt32(w, item.QueueSizeDiskSum)
-	if (item.QueueSizeDiskSum != 0) == false {
-		w = w[:backupIndexQueueSizeDiskSum]
-	}
-	backupIndexQueueSizeMemorySum := len(w)
-	w = basictl.JSONAddCommaIfNeeded(w)
-	w = append(w, `"queue_size_memory_sum":`...)
-	w = basictl.JSONWriteInt32(w, item.QueueSizeMemorySum)
-	if (item.QueueSizeMemorySum != 0) == false {
-		w = w[:backupIndexQueueSizeMemorySum]
-	}
-	backupIndexQueueSizeDiskUnsent := len(w)
-	w = basictl.JSONAddCommaIfNeeded(w)
-	w = append(w, `"queue_size_disk_unsent":`...)
-	w = basictl.JSONWriteInt32(w, item.QueueSizeDiskUnsent)
-	if (item.QueueSizeDiskUnsent != 0) == false {
-		w = w[:backupIndexQueueSizeDiskUnsent]
-	}
-	backupIndexQueueSizeDiskSumUnsent := len(w)
-	w = basictl.JSONAddCommaIfNeeded(w)
-	w = append(w, `"queue_size_disk_sum_unsent":`...)
-	w = basictl.JSONWriteInt32(w, item.QueueSizeDiskSumUnsent)
-	if (item.QueueSizeDiskSumUnsent != 0) == false {
-		w = w[:backupIndexQueueSizeDiskSumUnsent]
 	}
 	backupIndexOriginalSize := len(w)
 	w = basictl.JSONAddCommaIfNeeded(w)

--- a/internal/data_model/schema.tl
+++ b/internal/data_model/schema.tl
@@ -52,7 +52,7 @@ statshouse.multi_item#0c803e07
     = statshouse.MultiItem;
 
 statshouse.sourceBucket2#3af6e822
-      metrics: (vector (statshouse.multi_item)) // must be sorted by shard
+      metrics: (vector (statshouse.multi_item)) // must be sorted by aggregation shard
 
       sample_factors: (vector statshouse.sample_factor) // We need as compact representation as possible.
       ingestion_status_ok: (vector statshouse.sample_factor) // legacy, never sent by 1.0 agents. TODO - rename to unused
@@ -68,7 +68,7 @@ statshouse.sourceBucket2#3af6e822
 statshouse.sourceBucket3#16c4dd7b
     fields_mask: #
     // TODO: check how it is used and maybe change to a new version
-    metrics: (vector (statshouse.multi_item)) // must be sorted by shard
+    metrics: (vector (statshouse.multi_item)) // must be sorted by aggregation shard
     sample_factors: (vector statshouse.sample_factor) // We need as compact representation as possible.
     ingestion_status_ok2: (vector statshouse.ingestion_status2) // We need as compact representation as possible.
   = statshouse.SourceBucket3;
@@ -188,7 +188,6 @@ statshouse.sendSourceBucket3Response#0e177acc
     sharding:fields_mask.5?int // deprecated because sharding is now configured for each metric separately
     = String;
 
-// TODO: support sendKeepAlive (same or new)
 @readwrite statshouse.sendSourceBucket3#0d04aa3f
     fields_mask:#
     header: (statshouse.commonProxyHeader fields_mask)
@@ -198,13 +197,6 @@ statshouse.sendSourceBucket3Response#0e177acc
     // build stats
     build_commit:string
     build_commit_ts:int
-    // queue stats TODO: check if we still need it
-    queue_size_disk:int // set in sendSourceBucketCompressed
-    queue_size_memory:int
-    queue_size_disk_sum:int
-    queue_size_memory_sum:int
-    queue_size_disk_unsent:int
-    queue_size_disk_sum_unsent:int
     // data
     original_size:#
     compressed_data:string

--- a/internal/data_model/schema.tl
+++ b/internal/data_model/schema.tl
@@ -176,7 +176,7 @@ statshouse.sendSourceBucket3Response#0e177acc
     spare:fields_mask.1?true
     build_commit:string
     build_commit_date:int // deprecated, not sent by agents, not used by aggregators
-    build_commit_ts:int
+    build_commit_ts:#
     queue_size_disk:int
     queue_size_memory:int
     queue_size_disk_sum:fields_mask.2?int   // for all shard-replicas. Helps detect situation where only subset of aggregators is accessible.
@@ -196,7 +196,7 @@ statshouse.sendSourceBucket3Response#0e177acc
     spare:fields_mask.1?true
     // build stats
     build_commit:string
-    build_commit_ts:int
+    build_commit_ts:#
     // data
     original_size:#
     compressed_data:string

--- a/internal/format/builtin.go
+++ b/internal/format/builtin.go
@@ -1096,6 +1096,9 @@ Set by either agent or aggregator, depending on status.`,
 			}, {
 				Description: "commit_timestamp",
 				RawKind:     "timestamp",
+			}, {
+				Description: "commit_hash",
+				RawKind:     "hex",
 			}},
 		},
 		BuiltinMetricIDAgentReceivedPacketSize: {

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -77,8 +77,8 @@ const (
 	NamespaceSeparator     = ":"
 	NamespaceSeparatorRune = ':'
 
-	// if more than 0 then agents with older commitTs will be declined
-	LeastAllowedAgentCommitTs = 0
+	// agents with older commitTs will be declined
+	LeastAllowedAgentCommitTs uint32 = 0
 )
 
 // Do not change values, they are stored in DB

--- a/internal/vkgo/build/version.go
+++ b/internal/vkgo/build/version.go
@@ -7,6 +7,8 @@
 package build
 
 import (
+	"encoding/binary"
+	"encoding/hex"
 	"flag"
 	"fmt"
 	"log"
@@ -24,6 +26,7 @@ var (
 	time                string
 	machine             string
 	commit              string
+	commitTag           uint32
 	commitTimestamp     string
 	version             string
 	number              string
@@ -55,6 +58,11 @@ func Commit() string {
 	return commit
 }
 
+// appropriate for inserting into statshouse raw key
+func CommitTag() uint32 {
+	return commitTag
+}
+
 // UNIX timestampt seconds, so stable in any TZ
 func CommitTimestamp() uint32 {
 	return commitTimestampUint32
@@ -82,6 +90,9 @@ func init() {
 	appName = path.Base(os.Args[0])
 	ts, _ := strconv.ParseUint(commitTimestamp, 10, 32)
 	commitTimestampUint32 = uint32(ts)
+	if commitTagRaw, _ := hex.DecodeString(commit); len(commitTagRaw) >= 4 {
+		commitTag = binary.BigEndian.Uint32(commitTagRaw[:])
+	}
 	parseTrustedSubnetGroups()
 }
 


### PR DESCRIPTION
fix to keep alives broken in commit to master on 18 nov 2024

queue size as normal metric

harmonization of handle source bucket 2 & 3

agent timings have commit hash

build timestamp is explicit uint32 in scheme, converted to int32 for the purpose of using as a tag