### PR TITLE
improve timestamps clamping

### DIFF
--- a/internal/aggregator/aggregator_insert.go
+++ b/internal/aggregator/aggregator_insert.go
@@ -227,6 +227,8 @@ func appendBadge(rng *rand.Rand, res []byte, k *data_model.Key, v data_model.Ite
 			format.TagValueIDSrcIngestionStatusWarnDeprecatedStop,
 			format.TagValueIDSrcIngestionStatusWarnMapTagSetTwice,
 			format.TagValueIDSrcIngestionStatusWarnOldCounterSemantic,
+			format.TagValueIDSrcIngestionStatusWarnTimestampClampedPast,
+			format.TagValueIDSrcIngestionStatusWarnTimestampClampedFuture,
 			format.TagValueIDSrcIngestionStatusWarnMapInvalidRawTagValue:
 			return appendValueStat(rng, res, &data_model.Key{Timestamp: ts, Metric: format.BuiltinMetricIDBadges, Tags: [16]int32{0, format.TagValueIDBadgeIngestionWarnings, k.Tags[1]}}, "", v, metricCache, usedTimestamps, v3Format)
 		}

--- a/internal/data_model/transfer_test.go
+++ b/internal/data_model/transfer_test.go
@@ -198,7 +198,7 @@ func roundTripKey(key Key, bucketTimestamp uint32, newestTime uint32) *Key {
 	}
 
 	// Convert MultiItemBytes back to Key
-	reconstructedKey, _ := KeyFromStatshouseMultiItem(multiItemBytes, bucketTimestamp, newestTime)
+	reconstructedKey, _, _ := KeyFromStatshouseMultiItem(multiItemBytes, bucketTimestamp, newestTime)
 	return reconstructedKey
 }
 

--- a/internal/format/builtin.go
+++ b/internal/format/builtin.go
@@ -313,6 +313,8 @@ const (
 	TagValueIDSrcIngestionStatusWarnMapInvalidRawTagValue    = 52
 	TagValueIDSrcIngestionStatusWarnMapTagNameFoundDraft     = 53
 	TagValueIDSrcIngestionStatusErrShardingFailed            = 54
+	TagValueIDSrcIngestionStatusWarnTimestampClampedPast     = 55
+	TagValueIDSrcIngestionStatusWarnTimestampClampedFuture   = 56
 
 	TagValueIDPacketFormatLegacy   = 1
 	TagValueIDPacketFormatTL       = 2
@@ -713,6 +715,8 @@ This metric uses sampling budgets of metric it refers to, so flooding by errors 
 					TagValueIDSrcIngestionStatusWarnMapInvalidRawTagValue:    "warn_map_invalid_raw_tag_value",
 					TagValueIDSrcIngestionStatusWarnMapTagNameFoundDraft:     "warn_tag_draft_found",
 					TagValueIDSrcIngestionStatusErrShardingFailed:            "err_sharding_failed",
+					TagValueIDSrcIngestionStatusWarnTimestampClampedPast:     "warn_timestamp_clamped_past",
+					TagValueIDSrcIngestionStatusWarnTimestampClampedFuture:   "warn_timestamp_clamped_future",
 				}),
 			}, {
 				Description: "tag_id",


### PR DESCRIPTION
New ingestion statuses - warn timestamp clamped past/future

Agents do not clamp any more, so rules can be easily adjusted on aggregators