### PR TITLE
[journal] increase protect timeout for agent

### DIFF
--- a/cmd/statshouse/statshouse-tools.go
+++ b/cmd/statshouse/statshouse-tools.go
@@ -250,7 +250,7 @@ func FakeBenchmarkMetricsPerSecond(listenAddr string) {
 		}
 		goodMetric.Inc()
 	}
-	metricStorage := metajournal.MakeMetricsStorage("", nil, nil)
+	metricStorage := metajournal.MakeMetricsStorage("", data_model.JournalDDOSProtectionTimeout, nil, nil)
 	metricStorage.Journal().Start(nil, nil, dolphinLoader)
 	mapper := mapping.NewMapper("", pmcLoader, nil, nil, 1000, handleMappedMetric)
 
@@ -470,7 +470,7 @@ func mainSimulator() {
 
 	argv.configAgent.AggregatorAddresses = strings.Split(argv.aggAddr, ",")
 
-	metricStorage := metajournal.MakeMetricsStorage("simulator", nil, nil)
+	metricStorage := metajournal.MakeMetricsStorage("simulator", data_model.JournalDDOSProtectionTimeout, nil, nil)
 
 	client, cryptoKey := argvCreateClient()
 
@@ -627,7 +627,7 @@ func mainPublishTagDrafts() {
 		work     = make(map[int32]map[int32]format.MetricMetaValue)
 		workCond = sync.NewCond(&workMu)
 	)
-	storage = metajournal.MakeMetricsStorage("", nil,
+	storage = metajournal.MakeMetricsStorage("", data_model.JournalDDOSProtectionTimeout, nil,
 		func(configID int32, configString string) {
 			switch configID {
 			case format.KnownTagsConfigID:

--- a/cmd/statshouse/statshouse.go
+++ b/cmd/statshouse/statshouse.go
@@ -270,7 +270,7 @@ func mainAgent(aesPwd string, dc *pcache.DiskCache) int {
 
 	var (
 		receiversUDP  []*receiver.UDP
-		metricStorage = metajournal.MakeMetricsStorage(argv.configAgent.Cluster, dc, nil)
+		metricStorage = metajournal.MakeMetricsStorage(argv.configAgent.Cluster, data_model.JournalDDOSProtectionAgentTimeout, dc, nil)
 	)
 	envLoader, _ := env.ListenEnvFile(argv.envFilePath)
 

--- a/internal/aggregator/aggregator.go
+++ b/internal/aggregator/aggregator.go
@@ -278,7 +278,7 @@ func MakeAggregator(dc *pcache.DiskCache, storageDir string, listenAddr string, 
 	if config.AutoCreate {
 		a.autoCreate = newAutoCreate(a, metadataClient, config.AutoCreateDefaultNamespace)
 	}
-	a.metricStorage = metajournal.MakeMetricsStorage(a.config.Cluster, dc, func(configID int32, configS string) {
+	a.metricStorage = metajournal.MakeMetricsStorage(a.config.Cluster, data_model.JournalDDOSProtectionTimeout, dc, func(configID int32, configS string) {
 		a.scrape.applyConfig(configID, configS)
 		if a.autoCreate != nil {
 			a.autoCreate.applyConfig(configID, configS)

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -578,7 +578,7 @@ func NewHandler(staticDir fs.FS, jsSettings JSSettings, showInvisible bool, chV1
 		return nil, fmt.Errorf("failed to marshal settings to JSON: %w", err)
 	}
 	cl := config.NewConfigListener(data_model.APIRemoteConfig, cfg)
-	metricStorage := metajournal.MakeMetricsStorage(diskCacheSuffix, diskCache, nil, cl.ApplyEventCB)
+	metricStorage := metajournal.MakeMetricsStorage(diskCacheSuffix, data_model.JournalDDOSProtectionTimeout, diskCache, nil, cl.ApplyEventCB)
 	h := &Handler{
 		HandlerOptions: opt,
 		showInvisible:  showInvisible,

--- a/internal/data_model/constants.go
+++ b/internal/data_model/constants.go
@@ -86,8 +86,9 @@ const (
 	ClickHouseTimeoutInsert   = 5 * time.Minute  // reduces chance of duplicates
 	ClickHouseTimeoutShutdown = 30 * time.Second // we do not delay aggregator shutdown by more than this time
 
-	KeepAliveMaxBackoff          = 30 * time.Second // for cases when aggregators quickly return error
-	JournalDDOSProtectionTimeout = 50 * time.Millisecond
+	KeepAliveMaxBackoff               = 30 * time.Second      // for cases when aggregators quickly return error
+	JournalDDOSProtectionTimeout      = 50 * time.Millisecond // protects the metadata engine from overload
+	JournalDDOSProtectionAgentTimeout = 1 * time.Second       // protects CPU usage of agent
 
 	InternalLogInsertInterval = 5 * time.Second
 

--- a/internal/metajournal/meta_metrics.go
+++ b/internal/metajournal/meta_metrics.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/vkcom/statshouse/internal/data_model"
 	"github.com/vkcom/statshouse/internal/data_model/gen2/tlmetadata"
@@ -61,7 +62,7 @@ type MetricsStorage struct {
 	journal *Journal // can be easily moved out, if desired
 }
 
-func MakeMetricsStorage(namespaceSuffix string, dc *pcache.DiskCache, applyPromConfig ApplyPromConfig, applyEvents ...ApplyEvent) *MetricsStorage {
+func MakeMetricsStorage(namespaceSuffix string, journalRequestDelay time.Duration, dc *pcache.DiskCache, applyPromConfig ApplyPromConfig, applyEvents ...ApplyEvent) *MetricsStorage {
 	result := &MetricsStorage{
 		metaSnapshot: &metaSnapshot{
 			metricsByNameSnapshot: map[string]*format.MetricMetaValue{},
@@ -83,7 +84,7 @@ func MakeMetricsStorage(namespaceSuffix string, dc *pcache.DiskCache, applyPromC
 	for id, g := range format.BuiltInNamespaceDefault {
 		result.builtInNamespace[id] = g
 	}
-	result.journal = MakeJournal(namespaceSuffix, dc, append([]ApplyEvent{result.ApplyEvent}, applyEvents...))
+	result.journal = MakeJournal(namespaceSuffix, journalRequestDelay, dc, append([]ApplyEvent{result.ApplyEvent}, applyEvents...))
 	return result
 }
 

--- a/internal/metajournal/meta_metrics_test.go
+++ b/internal/metajournal/meta_metrics_test.go
@@ -12,13 +12,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/vkcom/statshouse/internal/data_model"
 
 	"github.com/vkcom/statshouse/internal/data_model/gen2/tlmetadata"
 	"github.com/vkcom/statshouse/internal/format"
 )
 
 func newMetricStorage(loader MetricsStorageLoader) *MetricsStorage {
-	result := MakeMetricsStorage("", nil, nil)
+	result := MakeMetricsStorage("", data_model.JournalDDOSProtectionTimeout, nil, nil)
 	result.journal.metaLoader = loader
 	result.journal.parseDiscCache()
 	return result


### PR DESCRIPTION
To prevent agent overloading during the update of the meta journal, the protection timeout was increased from 50 ms to 1 second.