### PR TITLE
Better api ClickHouse metrics

### DIFF
--- a/internal/api/endpoint_stat.go
+++ b/internal/api/endpoint_stat.go
@@ -192,16 +192,17 @@ func ChRequestsMetric(shard int, aggHost string, table string, ok bool) {
 		}, 1)
 }
 
-func ChSelectProfile(isFast, isLight, isHardware bool, info proto.Profile, err error) {
-	chSelectPushMetric(format.BuiltinMetricMetaAPISelectBytes.Name, isFast, isLight, isHardware, float64(info.Bytes), err)
-	chSelectPushMetric(format.BuiltinMetricMetaAPISelectRows.Name, isFast, isLight, isHardware, float64(info.Rows), err)
+func ChSelectProfile(isFast, isLight, isHardware bool, metric *format.MetricMetaValue, user, table, kind string, info proto.Profile, err error) {
+	chSelectPushMetricFull(format.BuiltinMetricMetaAPISelectBytes.Name, isFast, isLight, isHardware, float64(info.Bytes), metric, user, table, kind, err)
+	chSelectPushMetricFull(format.BuiltinMetricMetaAPISelectRows.Name, isFast, isLight, isHardware, float64(info.Rows), metric, user, table, kind, err)
 }
 
-func ChSelectProfileEvents(isFast, isLight, isHardware bool, osCPUVirtualTimeMicroseconds uint64, err error) {
-	chSelectPushMetric(
+func ChSelectProfileEvents(isFast, isLight, isHardware bool, metric *format.MetricMetaValue, user, table, kind string, osCPUVirtualTimeMicroseconds uint64, err error) {
+	chSelectPushMetricFull(
 		format.BuiltinMetricMetaAPISelectOSCPUVirtualTime.Name,
 		isFast, isLight, isHardware,
-		float64(osCPUVirtualTimeMicroseconds),
+		float64(osCPUVirtualTimeMicroseconds)/1e6, // convert to seconds
+		metric, user, table, kind,
 		err,
 	)
 }
@@ -222,17 +223,28 @@ func modeStr(isFast, isLight, isHardware bool) string {
 	return mode
 }
 
-func chSelectPushMetric(metric string, isFast, isLight, isHardware bool, data float64, err error) {
-	m := statshouse.GetMetricRef(
+func chSelectPushMetricFull(metric string, isFast, isLight, isHardware bool, data float64, mm *format.MetricMetaValue, user, table, kind string, err error) {
+	ok := "ok"
+	if err != nil {
+		ok = "error"
+	}
+	var metricID int32
+	if mm != nil {
+		metricID = mm.MetricID
+	}
+	statshouse.Value(
 		metric,
 		statshouse.Tags{
 			1: modeStr(isFast, isLight, isHardware),
+			2: strconv.Itoa(int(metricID)),
+			3: table,
+			4: kind,
+			5: ok,
+			6: getStatTokenName(user),
+			7: user,
 		},
+		data,
 	)
-	m.Value(data)
-	if err != nil {
-		m.StringTop(err.Error())
-	}
 }
 
 func ChCacheRate(cachedRows, chRows int, metricID int32, table, kind string) {

--- a/internal/api/endpoint_stat.go
+++ b/internal/api/endpoint_stat.go
@@ -197,6 +197,15 @@ func ChSelectProfile(isFast, isLight, isHardware bool, info proto.Profile, err e
 	chSelectPushMetric(format.BuiltinMetricMetaAPISelectRows.Name, isFast, isLight, isHardware, float64(info.Rows), err)
 }
 
+func ChSelectProfileEvents(isFast, isLight, isHardware bool, osCPUVirtualTimeMicroseconds uint64, err error) {
+	chSelectPushMetric(
+		format.BuiltinMetricMetaAPISelectOSCPUVirtualTime.Name,
+		isFast, isLight, isHardware,
+		float64(osCPUVirtualTimeMicroseconds),
+		err,
+	)
+}
+
 func modeStr(isFast, isLight, isHardware bool) string {
 	mode := "slow"
 	if isFast {

--- a/internal/api/endpoint_stat.go
+++ b/internal/api/endpoint_stat.go
@@ -171,7 +171,7 @@ func ChSelectMetricDuration(duration time.Duration, metric *format.MetricMetaVal
 			5: ok,
 			6: getStatTokenName(user),
 			7: user,
-			8: strconv.Itoa(int(uint32(metricID) % 16)), // experimental to see load distribution if we shard data by metricID
+			8: strconv.Itoa(int(uint32(metricID)%16) + 1), // to see load distribution if we shard data by metricID
 		},
 		duration.Seconds())
 }

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -930,8 +930,8 @@ func (h *requestHandler) doSelect(ctx context.Context, meta chutil.QueryMetaInto
 	h.endpointStat.reportTiming("ch-select", info.QueryDuration)
 	h.endpointStat.reportTiming("wait-lock", info.WaitLockDuration)
 	ChSelectMetricDuration(info.QueryDuration, meta.Metric, meta.User, meta.Table, "", meta.IsFast, meta.IsLight, meta.IsHardware, err)
-	ChSelectProfile(meta.IsFast, meta.IsLight, meta.IsHardware, info.Profile, err)
-	ChSelectProfileEvents(meta.IsFast, meta.IsLight, meta.IsHardware, info.OSCPUVirtualTimeMicroseconds, err)
+	ChSelectProfile(meta.IsFast, meta.IsLight, meta.IsHardware, meta.Metric, meta.User, meta.Table, "", info.Profile, err)
+	ChSelectProfileEvents(meta.IsFast, meta.IsLight, meta.IsHardware, meta.Metric, meta.User, meta.Table, "", info.OSCPUVirtualTimeMicroseconds, err)
 	// TODO: add shard
 	ChRequestsMetric(0, info.Host, meta.Table, err == nil)
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -931,6 +931,7 @@ func (h *requestHandler) doSelect(ctx context.Context, meta chutil.QueryMetaInto
 	h.endpointStat.reportTiming("wait-lock", info.WaitLockDuration)
 	ChSelectMetricDuration(info.QueryDuration, meta.Metric, meta.User, meta.Table, "", meta.IsFast, meta.IsLight, meta.IsHardware, err)
 	ChSelectProfile(meta.IsFast, meta.IsLight, meta.IsHardware, info.Profile, err)
+	ChSelectProfileEvents(meta.IsFast, meta.IsLight, meta.IsHardware, info.OSCPUVirtualTimeMicroseconds, err)
 	// TODO: add shard
 	ChRequestsMetric(0, info.Host, meta.Table, err == nil)
 

--- a/internal/format/builtin.go
+++ b/internal/format/builtin.go
@@ -157,6 +157,7 @@ var (
 		-139:                                    BuiltinMetricMetaAggOldMetrics,
 		-140:                                    BuiltinMetricMetaApiChRequests,
 		BuiltinMetricIDMigrationLog:             BuiltinMetricMetaMigrationLog,
+		-142:                                    BuiltinMetricMetaAPISelectOSCPUVirtualTime,
 	}
 
 	// BuiltInGroupDefault can be overridden by journal, don't use directly

--- a/internal/format/builtin.go
+++ b/internal/format/builtin.go
@@ -88,7 +88,6 @@ var (
 		-66:                                     BuiltinMetricMetaAPISelectBytes,
 		-67:                                     BuiltinMetricMetaAPISelectRows,
 		-68:                                     BuiltinMetricMetaAPISelectDuration,
-		-70:                                     BuiltinMetricMetaAPISourceSelectRows,
 		-71:                                     BuiltinMetricMetaSystemMetricScrapeDuration,
 		-72:                                     BuiltinMetricMetaMetaServiceTime,
 		-73:                                     BuiltinMetricMetaMetaClientWaits,

--- a/internal/format/builtin_metrics.go
+++ b/internal/format/builtin_metrics.go
@@ -1251,25 +1251,7 @@ var BuiltinMetricMetaAPISelectDuration = &MetricMetaValue{
 }
 
 // const BuiltinMetricIDAgentHistoricQueueSizeSum = -69 // Removed, not needed after queue size metric is written by agents
-var BuiltinMetricMetaAPISourceSelectRows = &MetricMetaValue{
-	Name:                    "__api_ch_source_select_rows",
-	Kind:                    MetricKindValue,
-	Description:             "Value of this metric number of rows was selected from DB or cache",
-	NoSampleAgent:           false,
-	BuiltinAllowedToReceive: false,
-	WithAgentEnvRouteArch:   false,
-	WithAggregatorID:        true,
-	Tags: []MetricMetaTag{{
-		Description: "source type",
-	}, {
-		Description: "metric",
-		BuiltinKind: BuiltinKindMetric,
-	}, {
-		Description: "table",
-	}, {
-		Description: "kind",
-	}},
-}
+// const BuiltinMetricIDAPISourceSelectRows = -70 // Removed, was not used
 
 var BuiltinMetricMetaSystemMetricScrapeDuration = &MetricMetaValue{
 	Name:                    "__system_metrics_duration",

--- a/internal/format/builtin_metrics.go
+++ b/internal/format/builtin_metrics.go
@@ -1171,6 +1171,21 @@ var BuiltinMetricMetaAPISelectRows = &MetricMetaValue{
 	}},
 }
 
+var BuiltinMetricMetaAPISelectOSCPUVirtualTime = &MetricMetaValue{
+	Name: "__api_ch_select_os_cpu_virtual_time_us",
+	Kind: MetricKindValue,
+	// TODO replace with logs
+	StringTopDescription:    "error",
+	Description:             "OS CPU virtual time in microseconds reported by ClickHouse ProfileEvents for SELECT",
+	NoSampleAgent:           false,
+	BuiltinAllowedToReceive: true,
+	WithAgentEnvRouteArch:   false,
+	WithAggregatorID:        false,
+	Tags: []MetricMetaTag{{
+		Description: "query type",
+	}},
+}
+
 var BuiltinMetricMetaAPISelectDuration = &MetricMetaValue{
 	Name:                    "__api_ch_select_duration",
 	Kind:                    MetricKindValue,

--- a/internal/format/builtin_metrics.go
+++ b/internal/format/builtin_metrics.go
@@ -1142,10 +1142,8 @@ var BuiltinMetricMetaGroupSizeAfterSampling = &MetricMetaValue{
 }
 
 var BuiltinMetricMetaAPISelectBytes = &MetricMetaValue{
-	Name: "__api_ch_select_bytes",
-	Kind: MetricKindValue,
-	// TODO replace with logs
-	StringTopDescription:    "error",
+	Name:                    "__api_ch_select_bytes",
+	Kind:                    MetricKindValue,
 	Description:             "Number of bytes was handled by ClickHouse SELECT query",
 	NoSampleAgent:           false,
 	BuiltinAllowedToReceive: true,
@@ -1153,14 +1151,25 @@ var BuiltinMetricMetaAPISelectBytes = &MetricMetaValue{
 	WithAggregatorID:        false,
 	Tags: []MetricMetaTag{{
 		Description: "query type",
+	}, {
+		Description: "metric",
+		BuiltinKind: BuiltinKindMetric,
+	}, {
+		Description: "table",
+	}, {
+		Description: "kind",
+	}, {
+		Description: "status",
+	}, {
+		Description: "token-short",
+	}, {
+		Description: "token-long",
 	}},
 }
 
 var BuiltinMetricMetaAPISelectRows = &MetricMetaValue{
-	Name: "__api_ch_select_rows",
-	Kind: MetricKindValue,
-	// TODO replace with logs
-	StringTopDescription:    "error",
+	Name:                    "__api_ch_select_rows",
+	Kind:                    MetricKindValue,
 	Description:             "Number of rows was handled by ClickHouse SELECT query",
 	NoSampleAgent:           false,
 	BuiltinAllowedToReceive: true,
@@ -1168,21 +1177,46 @@ var BuiltinMetricMetaAPISelectRows = &MetricMetaValue{
 	WithAggregatorID:        false,
 	Tags: []MetricMetaTag{{
 		Description: "query type",
+	}, {
+		Description: "metric",
+		BuiltinKind: BuiltinKindMetric,
+	}, {
+		Description: "table",
+	}, {
+		Description: "kind",
+	}, {
+		Description: "status",
+	}, {
+		Description: "token-short",
+	}, {
+		Description: "token-long",
 	}},
 }
 
 var BuiltinMetricMetaAPISelectOSCPUVirtualTime = &MetricMetaValue{
-	Name: "__api_ch_select_os_cpu_virtual_time_us",
-	Kind: MetricKindValue,
-	// TODO replace with logs
-	StringTopDescription:    "error",
-	Description:             "OS CPU virtual time in microseconds reported by ClickHouse ProfileEvents for SELECT",
+	Name:                    "__api_ch_select_os_cpu_virtual_time",
+	Kind:                    MetricKindValue,
+	MetricType:              MetricSecond,
+	Description:             "OS CPU virtual time in seconds reported by ClickHouse ProfileEvents for SELECT",
 	NoSampleAgent:           false,
 	BuiltinAllowedToReceive: true,
 	WithAgentEnvRouteArch:   false,
 	WithAggregatorID:        false,
 	Tags: []MetricMetaTag{{
 		Description: "query type",
+	}, {
+		Description: "metric",
+		BuiltinKind: BuiltinKindMetric,
+	}, {
+		Description: "table",
+	}, {
+		Description: "kind",
+	}, {
+		Description: "status",
+	}, {
+		Description: "token-short",
+	}, {
+		Description: "token-long",
 	}},
 }
 

--- a/internal/format/builtin_metrics.go
+++ b/internal/format/builtin_metrics.go
@@ -1245,7 +1245,7 @@ var BuiltinMetricMetaAPISelectDuration = &MetricMetaValue{
 	}, {
 		Description: "token-long",
 	}, {
-		Description: "shard", // metric % 16 for now, experimental
+		Description: "shard_key", // metric % 16 + 1 for now, experimental
 		RawKind:     "int",
 	}},
 }


### PR DESCRIPTION
Add metric `__api_ch_select_os_cpu_virtual_time` to see CPU utilized by ClickHouse for request. With user/metric/lane groupings.
Add same tags into `__api_ch_source_select_rows` and `__api_ch_source_select_bytes`