### PR TITLE
tiny fixes to autoconfig metric

### DIFF
--- a/internal/aggregator/aggregator.go
+++ b/internal/aggregator/aggregator.go
@@ -551,27 +551,27 @@ func (a *Aggregator) agentBeforeFlushBucketFunc(_ *agent.Agent, nowUnix uint32) 
 }
 
 func (a *Aggregator) checkShardConfigurationTotal(shardReplicaTotal int32) error {
-	if int(shardReplicaTotal) == len(a.addresses) {
+	if shardReplicaTotal == int32(len(a.addresses)) {
 		return nil
 	}
-	if a.config.PreviousNumShards != 0 && int(shardReplicaTotal) == a.config.PreviousNumShards {
+	if a.config.PreviousNumShards != 0 && shardReplicaTotal == int32(a.config.PreviousNumShards) {
 		return nil
 	}
 	return fmt.Errorf("statshouse misconfiguration! shard*replicas total sent by source (%d) does not match shard*replicas total of aggregator (%d) or --previous-shards (%d)", shardReplicaTotal, len(a.addresses), a.config.PreviousNumShards)
 }
 
-func (a *Aggregator) checkShardConfiguration(shardReplica int32, shardReplicaTotal int32) error {
+func (a *Aggregator) checkShardConfiguration(shardReplica int32, shardReplicaTotal int32) (int32, error) {
+	ourShardReplica := (a.shardKey-1)*3 + (a.replicaKey - 1) // shardKey is 1 for shard 0
 	if err := a.checkShardConfigurationTotal(shardReplicaTotal); err != nil {
-		return err
+		return ourShardReplica, err
 	}
 	if a.withoutCluster { // No checks for local testing, when config.Replica == ""
-		return nil
+		return ourShardReplica, nil
 	}
-	ourShardReplica := int((a.shardKey-1)*3 + (a.replicaKey - 1)) // shardKey is 1 for shard 0
-	if int(shardReplica) != ourShardReplica {
-		return fmt.Errorf("statshouse misconfiguration! shard*replica sent by source (%d) does not match shard*replica expected by aggregator (%d) with shard:replica %d:%d", shardReplica, ourShardReplica, a.shardKey, a.replicaKey)
+	if shardReplica != ourShardReplica {
+		return ourShardReplica, fmt.Errorf("statshouse misconfiguration! shard*replica sent by source (%d) does not match shard*replica expected by aggregator (%d) with shard:replica %d:%d", shardReplica, ourShardReplica, a.shardKey, a.replicaKey)
 	}
-	return nil
+	return ourShardReplica, nil
 }
 
 func selectShardReplica(khAddr, khUser, khPassword string, cluster string, listenPort string) (shardKey int32, replicaKey int32, addresses []string, err error) {

--- a/internal/aggregator/aggregator_handlers.go
+++ b/internal/aggregator/aggregator_handlers.go
@@ -125,7 +125,7 @@ func (a *Aggregator) handleGetConfig3(_ context.Context, hctx *rpc.HandlerContex
 	cc := a.getConfigResult3()
 	if args.IsSetPreviousConfig() && equalConfigResult3(args.PreviousConfig, cc) {
 		a.sh2.AddCounterHostAERA(nowUnix, format.BuiltinMetricMetaAutoConfig,
-			[]int32{0, 0, 0, 0, format.TagValueIDAutoConfigErrorKeepAlive},
+			[]int32{0, 0, 0, 0, format.TagValueIDAutoConfigLongpoll},
 			1, hostTag, aera)
 		// longpoll forever until aggregator restarts
 		return hctx.HijackResponse(a.testConnection) // those hctx are never added there so cancelling is NOP
@@ -232,10 +232,10 @@ func (a *Aggregator) handleSendSourceBucket(hctx *rpc.HandlerContext, args tlsta
 	}
 
 	a.mu.Lock()
-	if err := a.checkShardConfiguration(args.Header.ShardReplica, args.Header.ShardReplicaTotal); err != nil {
+	if ourShardReplica, err := a.checkShardConfiguration(args.Header.ShardReplica, args.Header.ShardReplicaTotal); err != nil {
 		a.mu.Unlock()
 		a.sh2.AddCounterHostAERA(nowUnix, format.BuiltinMetricMetaAutoConfig,
-			[]int32{0, 0, 0, 0, format.TagValueIDAutoConfigErrorSend, args.Header.ShardReplica, args.Header.ShardReplicaTotal},
+			[]int32{0, 0, 0, 0, format.TagValueIDAutoConfigErrorSend, args.Header.ShardReplica, args.Header.ShardReplicaTotal, ourShardReplica, int32(len(a.addresses))},
 			1, hostTag, aera)
 		return err.Error(), nil, true
 	}
@@ -746,10 +746,10 @@ func (a *Aggregator) handleSendKeepAliveAny(hctx *rpc.HandlerContext, args tlsta
 	}
 
 	a.mu.Lock()
-	if err := a.checkShardConfiguration(args.Header.ShardReplica, args.Header.ShardReplicaTotal); err != nil {
+	if ourShardReplica, err := a.checkShardConfiguration(args.Header.ShardReplica, args.Header.ShardReplicaTotal); err != nil {
 		a.mu.Unlock()
 		a.sh2.AddCounterHostAERA(nowUnix, format.BuiltinMetricMetaAutoConfig,
-			[]int32{0, 0, 0, 0, format.TagValueIDAutoConfigErrorKeepAlive, args.Header.ShardReplica, args.Header.ShardReplicaTotal},
+			[]int32{0, 0, 0, 0, format.TagValueIDAutoConfigErrorKeepAlive, args.Header.ShardReplica, args.Header.ShardReplicaTotal, ourShardReplica, int32(len(a.addresses))},
 			1, hostTag, aera)
 		return err
 	}

--- a/internal/format/builtin_metrics.go
+++ b/internal/format/builtin_metrics.go
@@ -721,12 +721,19 @@ Ingress proxies first proxy request (to record host and IP of agent), then repla
 			TagValueIDAutoConfigErrorSend:      "err_send",
 			TagValueIDAutoConfigErrorKeepAlive: "err_keep_alive",
 			TagValueIDAutoConfigWrongCluster:   "err_config_cluster",
+			TagValueIDAutoConfigLongpoll:       "ok_longpoll",
 		}),
 	}, {
 		Description: "shard_replica",
 		RawKind:     "int",
 	}, {
 		Description: "total_shard_replicas",
+		RawKind:     "int",
+	}, {
+		Description: "our_shard_replica",
+		RawKind:     "int",
+	}, {
+		Description: "our_total_shard_replicas",
 		RawKind:     "int",
 	}},
 }

--- a/internal/format/builtin_tags.go
+++ b/internal/format/builtin_tags.go
@@ -268,6 +268,7 @@ const (
 	TagValueIDAutoConfigErrorSend      = 2
 	TagValueIDAutoConfigErrorKeepAlive = 3
 	TagValueIDAutoConfigWrongCluster   = 4
+	TagValueIDAutoConfigLongpoll       = 5
 
 	TagValueIDSizeCounter           = 1
 	TagValueIDSizeValue             = 2


### PR DESCRIPTION
we have many agents which send to the wrong aggregators.

we must investigate them, so we tweak our __autoconfig metric.

https://statshouse.mvk.com/view?t=0&f=-3600&s=__autoconfig&g=60&qb=12&qb=13&qb=4&qb=5&qf=4-+3&qf=5-+0&qf=5-+1&qf=5-+2&qf=6%7E+0&n=40