### PR TITLE
fix: repository language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,6 @@
 /statshouse-ui/public/openapi/*.css              linguist-vendored
 /internal/sqlite/sqlite0/*.c                     linguist-vendored
 /internal/sqlite/sqlite0/*.h                     linguist-vendored
-/internal/sqlitev2/sqlite0/*.c                   linguist-vendored
-/internal/sqlitev2/sqlite0/*.h                   linguist-vendored
+/internal/vkgo/sqlitev2/sqlite0/*.c              linguist-vendored
+/internal/vkgo/sqlitev2/sqlite0/*.h              linguist-vendored
 /internal/data_model/gen2/**                     linguist-generated


### PR DESCRIPTION
After https://github.com/VKCOM/statshouse/pull/2114, the language usage count in the project broke:

<img width="353" height="185" alt="Screenshot 2025-12-15 at 01 30 19" src="https://github.com/user-attachments/assets/614e5fe7-f439-44a6-abc1-d71743fe7621" />
