### PR TITLE
Add decay to query time

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -889,7 +889,10 @@ func (h *requestHandler) doSelect(ctx context.Context, meta chutil.QueryMetaInto
 	ChSelectProfileEvents(meta.IsFast, meta.IsLight, meta.IsHardware, meta.Metric, meta.User, meta.Table, "", info.OSCPUVirtualTimeMicroseconds, info.ErrorCode, err)
 	ChRequestsMetric(info.Shard, info.Host, meta.Table, info.ErrorCode, err == nil)
 
-	return err
+	if err != nil {
+		return fmt.Errorf("%w (error_code=%s (%d))", err, chutil.ErrorCodeName(info.ErrorCode), info.ErrorCode)
+	}
+	return nil
 }
 
 func (h *Handler) getMetricNameWithNamespace(metricID int32) (string, error) {

--- a/internal/chutil/chutil.go
+++ b/internal/chutil/chutil.go
@@ -38,8 +38,10 @@ type connPool struct {
 	servers             []serverCH
 	sem                 *queue.Queue
 	shardSems           []*queue.Queue // shard_id -> semaphore
-	avgQueryDurationNS  atomic.Int64   // exponentially smoothed average in nanoseconds
-	shardAvgQueryNS     []atomic.Int64 // avgQueryDurationNS per-shard
+	avgQueryDurationNS   atomic.Int64   // exponentially smoothed average in nanoseconds
+	shardAvgQueryNS      []atomic.Int64 // avgQueryDurationNS per-shard
+	lastPoolQueryTimeNS  atomic.Int64
+	lastShardQueryTimeNS []atomic.Int64
 }
 
 type serverCH struct {
@@ -120,16 +122,23 @@ const (
 )
 
 func newConnPool(poolName string, maxConn int, maxShardConn, shardCount int) *connPool {
-	return &connPool{
-		poolName:            poolName,
-		rnd:                 rand.New(),
-		maxActiveQuery:      maxConn,
-		maxShardActiveQuery: maxShardConn,
-		servers:             make([]serverCH, 0),
-		sem:                 queue.NewQueue(int64(maxConn)),
-		shardSems:           make([]*queue.Queue, shardCount),
-		shardAvgQueryNS:     make([]atomic.Int64, shardCount),
+	p := &connPool{
+		poolName:             poolName,
+		rnd:                  rand.New(),
+		maxActiveQuery:       maxConn,
+		maxShardActiveQuery:  maxShardConn,
+		servers:              make([]serverCH, 0),
+		sem:                  queue.NewQueue(int64(maxConn)),
+		shardSems:            make([]*queue.Queue, shardCount),
+		shardAvgQueryNS:      make([]atomic.Int64, shardCount),
+		lastShardQueryTimeNS: make([]atomic.Int64, shardCount),
 	}
+	now := time.Now().UnixNano()
+	p.lastPoolQueryTimeNS.Store(now)
+	for i := range p.lastShardQueryTimeNS {
+		p.lastShardQueryTimeNS[i].Store(now)
+	}
+	return p
 }
 
 func newConnPoolWithShards(poolName string, maxConn int, shardCount int, maxShardConnsRatio int) *connPool {
@@ -682,11 +691,14 @@ func (pool *connPool) recordQueryDuration(d time.Duration, shard int) {
 			}
 		}
 	}
+	now := time.Now().UnixNano()
 	if shard >= 0 && shard < len(pool.shardAvgQueryNS) {
 		update(&pool.shardAvgQueryNS[shard])
+		pool.lastShardQueryTimeNS[shard].Store(now)
 		return
 	}
 	update(&pool.avgQueryDurationNS)
+	pool.lastPoolQueryTimeNS.Store(now)
 }
 
 func throttling(replica int, r *rand.Rand, err error, trotCfg *ReplicaThrottleConfig) error {

--- a/internal/chutil/chutil.go
+++ b/internal/chutil/chutil.go
@@ -690,6 +690,27 @@ func BindQuery(query string, args ...any) (string, error) {
 //go:linkname clickHouseBind github.com/ClickHouse/clickhouse-go/v2.bind
 func clickHouseBind(tz *time.Location, query string, args ...interface{}) (string, error)
 
+func ErrorCodeName(code int) string {
+	switch code {
+	case format.TagValueIDAPIResponseExceptionCHUnknown:
+		return "unknown_ch_exception"
+	case format.TagValueIDAPIResponseExceptionCHTimeout:
+		return "timeout_during_ch"
+	case format.TagValueIDAPIResponseExceptionSemTimeout:
+		return "timeout_on_semaphore"
+	case format.TagValueIDAPIResponseExceptionSemError:
+		return "semaphore_error"
+	case format.TagValueIDAPIResponseExceptionLongCHTimeout:
+		return "fatal_ch_timeout"
+	case format.TagValueIDAPIResponseExceptionSemTooLate:
+		return "semaphore_too_late"
+	case format.TagValueIDAPIResponseExceptionCtxCanceled:
+		return "context_canceled"
+	default:
+		return fmt.Sprintf("unknown(%d)", code)
+	}
+}
+
 func modeStr(isFast, isLight, isHardware bool) string {
 	mode := "slow"
 	if isFast {

--- a/internal/chutil/chutil.go
+++ b/internal/chutil/chutil.go
@@ -661,18 +661,24 @@ func adjustSemCapacity(s []serverCH, sem *queue.Queue, maxSize int) {
 	sem.AdjustCapacity(uint64(capacity))
 }
 
+func applyDecay(avgNS int64, lastQueryTimeNS int64) time.Duration {
+	if avgNS <= 0 {
+		return 0
+	}
+	elapsed := time.Since(time.Unix(0, lastQueryTimeNS))
+	return time.Duration(decayAvgNS(avgNS, elapsed))
+}
+
 func (pool *connPool) getAvgQueryDuration(shard int) time.Duration {
 	if shard >= 0 && shard < len(pool.shardAvgQueryNS) {
-		if ns := pool.shardAvgQueryNS[shard].Load(); ns > 0 {
-			return time.Duration(ns)
-		}
-		return 0
+		// TOCTOU: avg and timestamp are read separately; acceptable for this heuristic.
+		// Timestamps are updated only on query completion, so long-running in-flight
+		// queries may appear as idle time causing decay; this is an acceptable trade-off
+		// because the 60s grace period covers most queries and rejected/failed queries
+		// should not keep the average fresh.
+		return applyDecay(pool.shardAvgQueryNS[shard].Load(), pool.lastShardQueryTimeNS[shard].Load())
 	}
-	ns := pool.avgQueryDurationNS.Load()
-	if ns <= 0 {
-		return 0
-	}
-	return time.Duration(ns)
+	return applyDecay(pool.avgQueryDurationNS.Load(), pool.lastPoolQueryTimeNS.Load())
 }
 
 func (pool *connPool) recordQueryDuration(d time.Duration, shard int) {

--- a/internal/chutil/chutil.go
+++ b/internal/chutil/chutil.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"slices"
 	"strconv"
 	"sync"
@@ -384,6 +385,26 @@ func (ch1 *ClickHouse) resolvePoolBy(meta QueryMetaInto) (*connPool, *ReplicaThr
 }
 
 const latencySlackCH = 130 // 30% upside
+
+const avgDecayGracePeriodNS int64 = int64(60 * time.Second)
+const avgDecayHalfLifeNS int64 = int64(60 * time.Second)
+
+func decayAvgNS(avgNS int64, elapsed time.Duration) int64 {
+	if avgNS <= 0 {
+		return 0
+	}
+	elapsedNS := int64(elapsed)
+	if elapsedNS <= avgDecayGracePeriodNS {
+		return avgNS
+	}
+	decayNS := elapsedNS - avgDecayGracePeriodNS
+	ratio := float64(decayNS) / float64(avgDecayHalfLifeNS)
+	result := float64(avgNS) * math.Pow(0.5, ratio)
+	if result < 1 {
+		return 0
+	}
+	return int64(result)
+}
 
 func (pool *connPool) selectCH(ctx context.Context, ch *ClickHouse, meta QueryMetaInto, query chgo.Query, trotCfg *ReplicaThrottleConfig) (info QueryHandleInfo, err error) {
 	query.OnProfile = func(_ context.Context, p proto.Profile) error {

--- a/internal/chutil/chutil_test.go
+++ b/internal/chutil/chutil_test.go
@@ -1,0 +1,149 @@
+package chutil
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecayAvgNS(t *testing.T) {
+	grace := time.Duration(avgDecayGracePeriodNS)
+	halfLife := time.Duration(avgDecayHalfLifeNS)
+
+	tests := []struct {
+		name    string
+		avgNS   int64
+		elapsed time.Duration
+		want    int64
+	}{
+		{
+			name:    "zero_input",
+			avgNS:   0,
+			elapsed: 5 * time.Minute,
+			want:    0,
+		},
+		{
+			name:    "negative_input",
+			avgNS:   -100,
+			elapsed: 5 * time.Minute,
+			want:    0,
+		},
+		{
+			name:    "within_grace_period",
+			avgNS:   1000,
+			elapsed: 30 * time.Second,
+			want:    1000,
+		},
+		{
+			name:    "within_grace_period_near_boundary",
+			avgNS:   1000,
+			elapsed: 59 * time.Second,
+			want:    1000,
+		},
+		{
+			name:    "at_grace_boundary",
+			avgNS:   1000,
+			elapsed: grace,
+			want:    1000,
+		},
+		{
+			name:    "just_past_grace",
+			avgNS:   1024,
+			elapsed: grace + 1,
+			want:    1023,
+		},
+		{
+			name:    "one_half_life",
+			avgNS:   1024,
+			elapsed: grace + halfLife,
+			want:    512,
+		},
+		{
+			name:    "two_half_lives",
+			avgNS:   1024,
+			elapsed: grace + 2*halfLife,
+			want:    256,
+		},
+		{
+			name:    "three_half_lives",
+			avgNS:   1024,
+			elapsed: grace + 3*halfLife,
+			want:    128,
+		},
+		{
+			name:    "five_half_lives",
+			avgNS:   1024,
+			elapsed: grace + 5*halfLife,
+			want:    32,
+		},
+		{
+			name:    "ten_half_lives",
+			avgNS:   1024,
+			elapsed: grace + 10*halfLife,
+			want:    1,
+		},
+		{
+			name:    "eleven_half_lives_rounds_to_zero",
+			avgNS:   1024,
+			elapsed: grace + 11*halfLife,
+			want:    0,
+		},
+		{
+			name:    "thirty_half_lives_returns_zero",
+			avgNS:   1 << 40,
+			elapsed: grace + 60*halfLife,
+			want:    0,
+		},
+		{
+			name:    "large_value_single_half_life",
+			avgNS:   1 << 30,
+			elapsed: grace + halfLife,
+			want:    1 << 29,
+		},
+		{
+			name:    "odd_value_one_half_life",
+			avgNS:   1001,
+			elapsed: grace + halfLife,
+			want:    500,
+		},
+		{
+			name:    "odd_value_two_half_lives",
+			avgNS:   1001,
+			elapsed: grace + 2*halfLife,
+			want:    250,
+		},
+		{
+			name:    "one_returns_zero_after_one_half_life",
+			avgNS:   1,
+			elapsed: grace + halfLife,
+			want:    0,
+		},
+		{
+			name:    "elapsed_zero",
+			avgNS:   500,
+			elapsed: 0,
+			want:    500,
+		},
+		{
+			name:    "large_elapsed_60_half_lives",
+			avgNS:   1 << 50,
+			elapsed: grace + 60*halfLife,
+			want:    0,
+		},
+		{
+			name:    "partial_half_life",
+			avgNS:   1024,
+			elapsed: grace + halfLife/2,
+			want:    int64(1024 * math.Pow(0.5, 0.5)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := decayAvgNS(tt.avgNS, tt.elapsed)
+			require.Equal(t, tt.want, got, "decayAvgNS(%d, %v)", tt.avgNS, tt.elapsed)
+		})
+	}
+}

--- a/internal/chutil/chutil_test.go
+++ b/internal/chutil/chutil_test.go
@@ -187,3 +187,41 @@ func TestDecayAvgNS(t *testing.T) {
 		})
 	}
 }
+
+func TestGetAvgQueryDuration_Dispatch(t *testing.T) {
+	pool := newConnPool("test", 10, 5, 2)
+	ns := int64(4 * time.Second)
+	now := time.Now().UnixNano()
+
+	pool.avgQueryDurationNS.Store(ns)
+	pool.lastPoolQueryTimeNS.Store(now)
+	pool.shardAvgQueryNS[0].Store(ns * 2)
+	pool.lastShardQueryTimeNS[0].Store(now)
+	pool.shardAvgQueryNS[1].Store(ns * 3)
+	pool.lastShardQueryTimeNS[1].Store(now)
+
+	poolGot := pool.getAvgQueryDuration(-1)
+	shard0Got := pool.getAvgQueryDuration(0)
+	shard1Got := pool.getAvgQueryDuration(1)
+	oobGot := pool.getAvgQueryDuration(99)
+
+	require.Equal(t, time.Duration(ns), poolGot, "shard -1 should use pool average")
+	require.Equal(t, time.Duration(ns*2), shard0Got, "shard 0 should use shard 0 average")
+	require.Equal(t, time.Duration(ns*3), shard1Got, "shard 1 should use shard 1 average")
+	require.Equal(t, time.Duration(ns), oobGot, "out-of-range shard should fall back to pool average")
+}
+
+func TestGetAvgQueryDuration_ZeroAverage(t *testing.T) {
+	pool := newConnPool("test", 10, 5, 2)
+	pool.avgQueryDurationNS.Store(0)
+	pool.lastPoolQueryTimeNS.Store(time.Now().Add(-10 * time.Minute).UnixNano())
+
+	got := pool.getAvgQueryDuration(-1)
+	require.Equal(t, time.Duration(0), got, "zero pool average should return 0 regardless of timestamp")
+
+	pool.shardAvgQueryNS[0].Store(0)
+	pool.lastShardQueryTimeNS[0].Store(time.Now().Add(-10 * time.Minute).UnixNano())
+
+	got = pool.getAvgQueryDuration(0)
+	require.Equal(t, time.Duration(0), got, "zero shard average should return 0 regardless of timestamp")
+}

--- a/internal/chutil/chutil_test.go
+++ b/internal/chutil/chutil_test.go
@@ -8,6 +8,46 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNewConnPoolTimestamps(t *testing.T) {
+	before := time.Now().UnixNano()
+	pool := newConnPool("test", 10, 5, 3)
+	after := time.Now().UnixNano()
+
+	poolTS := pool.lastPoolQueryTimeNS.Load()
+	require.GreaterOrEqual(t, poolTS, before, "lastPoolQueryTimeNS should be >= time before construction")
+	require.LessOrEqual(t, poolTS, after, "lastPoolQueryTimeNS should be <= time after construction")
+
+	require.Len(t, pool.lastShardQueryTimeNS, 3, "expected 3 shard timestamps")
+	for i := range pool.lastShardQueryTimeNS {
+		shardTS := pool.lastShardQueryTimeNS[i].Load()
+		require.GreaterOrEqual(t, shardTS, before, "shard %d timestamp should be >= time before construction", i)
+		require.LessOrEqual(t, shardTS, after, "shard %d timestamp should be <= time after construction", i)
+	}
+}
+
+func TestRecordQueryDurationTimestamps(t *testing.T) {
+	pool := newConnPool("test", 10, 5, 2)
+
+	before := time.Now().UnixNano()
+	pool.recordQueryDuration(100*time.Millisecond, -1)
+	after := time.Now().UnixNano()
+
+	poolTS := pool.lastPoolQueryTimeNS.Load()
+	require.GreaterOrEqual(t, poolTS, before, "pool timestamp should be >= time before call")
+	require.LessOrEqual(t, poolTS, after, "pool timestamp should be <= time after call")
+
+	before = time.Now().UnixNano()
+	pool.recordQueryDuration(100*time.Millisecond, 0)
+	after = time.Now().UnixNano()
+
+	shardTS := pool.lastShardQueryTimeNS[0].Load()
+	require.GreaterOrEqual(t, shardTS, before, "shard 0 timestamp should be >= time before call")
+	require.LessOrEqual(t, shardTS, after, "shard 0 timestamp should be <= time after call")
+
+	shard1TS := pool.lastShardQueryTimeNS[1].Load()
+	require.Less(t, shard1TS, before, "shard 1 timestamp should still be old value (not updated by shard 0 call)")
+}
+
 func TestDecayAvgNS(t *testing.T) {
 	grace := time.Duration(avgDecayGracePeriodNS)
 	halfLife := time.Duration(avgDecayHalfLifeNS)


### PR DESCRIPTION
Fixes `semaphore_too_late` behaviour introduced in:
https://github.com/VKCOM/statshouse/pull/2089

The problem is that average duration of requests can increase and become high enough that the preflight check always reject `doSelect` without making any actual requests to ClickHouse.
It's especially painful for `cache-cleanup` job that has 5s timeout, once avg duration is increased in `fastlight` lane beyond that, all requests in that lane start to fail.
But this issue is not limited to `cache-cleanup`, here we have locked both `fastlight` lane (for 5 days) and `fast_hardware` for half a day:
<img width="2640" height="1782" alt="image" src="https://github.com/user-attachments/assets/1c6d86a3-bdf7-4740-b954-0b315e927916" />

To mitigate this issue, I added a decay function that halves request expected time when there are no successful requests for more than a minute.