### PR TITLE
api: fix pointsCache stale reads and table multi-LOD column corruption

### DIFF
--- a/internal/api/pcache.go
+++ b/internal/api/pcache.go
@@ -40,10 +40,17 @@ type timeRange struct {
 
 type cacheEntry struct {
 	// Place atomics first to ensure proper alignment, see https://pkg.go.dev/sync/atomic#pkg-note-BUG
-	lru          atomic.Int64
+	lru      atomic.Int64
+	rows     map[timeRange]cachedRows
+	rowsSize int
+}
+
+// cachedRows keeps loadedAtNano per time range. A single entry holds many
+// ranges of the same query; storing one shared load time let a later load of
+// one range revalidate stale rows of another (invalidated) range.
+type cachedRows struct {
+	rows         []pSelectRow
 	loadedAtNano int64
-	rows         map[timeRange][]pSelectRow
-	rowsSize     int
 }
 
 func newPointsCache(approxMaxSize int, utcOffset int64, loader pointsLoadFunc, now func() time.Time) *pointsCache {
@@ -88,15 +95,13 @@ func (c *pointsCache) get(ctx context.Context, h *requestHandler, pq *queryBuild
 	e, ok := c.cache[key]
 	if !ok {
 		e = &cacheEntry{
-			lru:          atomic.Int64{},
-			loadedAtNano: 0,
-			rows:         map[timeRange][]pSelectRow{},
+			lru:  atomic.Int64{},
+			rows: map[timeRange]cachedRows{},
 		}
 		c.cache[key] = e
 	}
 
 	e.lru.Store(c.now().UnixNano())
-	e.loadedAtNano = loadedAtNano
 	tr := timeRange{from: lod.FromSec, to: lod.ToSec}
 	if _, ok := e.rows[tr]; !ok {
 		c.size += 1 + len(rows)
@@ -104,7 +109,7 @@ func (c *pointsCache) get(ctx context.Context, h *requestHandler, pq *queryBuild
 		c.size += len(rows)
 	}
 	e.rowsSize += len(rows)
-	e.rows[tr] = rows
+	e.rows[tr] = cachedRows{rows: rows, loadedAtNano: loadedAtNano}
 	return rows, nil
 }
 
@@ -119,13 +124,13 @@ func (c *pointsCache) loadCached(key string, from, to int64) ([]pSelectRow, bool
 		from: from,
 		to:   to,
 	}
-	row, ok := entry.rows[tr]
+	cr, ok := entry.rows[tr]
 	if !ok {
 		return nil, false
 	}
 	entry.lru.Store(c.now().UnixNano())
-	cachedIsValid := c.invalidatedAtNano.checkInvalidationLocked(entry.loadedAtNano, from, to)
-	return row, cachedIsValid
+	cachedIsValid := c.invalidatedAtNano.checkInvalidationLocked(cr.loadedAtNano, from, to)
+	return cr.rows, cachedIsValid
 }
 
 func (c *pointsCache) invalidate(times []int64) {

--- a/internal/api/pcache_stale_repro_test.go
+++ b/internal/api/pcache_stale_repro_test.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/VKCOM/statshouse/internal/data_model"
+)
+
+// Reproduces stale reads from pointsCache: cacheEntry.loadedAtNano is shared
+// across time ranges of the same query, so loading range B "revalidates"
+// range A's rows that were loaded before an invalidation.
+func TestPointsCacheStaleAfterOtherRangeLoad(t *testing.T) {
+	now := time.Now()
+	nowF := func() time.Time { return now }
+	generation := 0
+	loader := func(_ context.Context, _ *requestHandler, _ *queryBuilder, _ data_model.LOD) ([]pSelectRow, error) {
+		return []pSelectRow{{tsValues: tsValues{count: float64(generation)}}}, nil
+	}
+	c := newPointsCache(1000, 0, loader, nowF)
+	h := &requestHandler{Handler: &Handler{}}
+	q := &queryBuilder{}
+
+	base := now.Unix() - 3600 // within the mutable 48h window
+	lodA := data_model.LOD{FromSec: base, ToSec: base + 60}
+	lodB := data_model.LOD{FromSec: base + 120, ToSec: base + 180}
+
+	// load range A (generation 0)
+	generation = 0
+	rows, err := c.get(context.Background(), h, q, lodA, false)
+	require.NoError(t, err)
+	require.Equal(t, float64(0), rows[0].count)
+
+	// data for a second inside range A changes; invalidation arrives
+	now = now.Add(time.Second)
+	c.invalidate([]int64{base + 30})
+	generation = 1 // fresh data available from now on
+
+	// immediately after invalidation, range A correctly misses cache
+	_, ok := c.loadCached(q.getOrBuildCacheKey(), lodA.FromSec, lodA.ToSec)
+	require.False(t, ok, "range A must be invalid right after invalidation")
+
+	// more than invalidateLinger later, someone queries range B (same query key)
+	now = now.Add(invalidateLinger + time.Second)
+	_, err = c.get(context.Background(), h, q, lodB, false)
+	require.NoError(t, err)
+
+	// range A must still read as invalid: its rows were loaded before the
+	// invalidation. Before the fix, B's load refreshed a shared loadedAtNano
+	// and range A was served as fresh (returning pre-invalidation data).
+	rows, ok = c.loadCached(q.getOrBuildCacheKey(), lodA.FromSec, lodA.ToSec)
+	require.False(t, ok, "stale rows served: range A revalidated by range B's load, count=%v", rows[0].count)
+}

--- a/internal/api/table.go
+++ b/internal/api/table.go
@@ -132,16 +132,21 @@ func (h *requestHandler) getTableFromLODs(ctx context.Context, lods []data_model
 				used[ix] = struct{}{}
 				queryRows[ix].Data = q.appendRowValues(queryRows[ix].Data, &rows[i], tableReqParams.desiredStepMul, &lod)
 			}
-			for _, ix := range rowsIdx {
-				if _, ok := used[ix]; ok {
-					delete(used, ix)
-				} else {
-					queryRows[ix].Data = append(queryRows[ix].Data, NaN())
-				}
-			}
 			if hasMoreValues {
 				hasMore = true
 				break
+			}
+		}
+		// Pad rows that got no value for this handler-what with a NaN so every
+		// row's Data stays column-aligned. This must run once per handler-what,
+		// after all LODs: rows are keyed by (time, tags) and each key belongs to
+		// exactly one LOD (LODs cover disjoint time ranges), so padding per-LOD
+		// would append an extra NaN to a row for every other LOD in this pass.
+		for _, ix := range rowsIdx {
+			if _, ok := used[ix]; ok {
+				delete(used, ix)
+			} else {
+				queryRows[ix].Data = append(queryRows[ix].Data, NaN())
 			}
 		}
 	}

--- a/internal/api/table_multilod_repro_test.go
+++ b/internal/api/table_multilod_repro_test.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/VKCOM/statshouse/internal/data_model"
+	"github.com/VKCOM/statshouse/internal/format"
+	"github.com/VKCOM/statshouse/internal/promql"
+)
+
+// Reproduces the multi-LOD column corruption: when a table query spans more
+// than one LOD, rows from an earlier LOD used to get an extra NaN appended for
+// every subsequent LOD, so Data column counts diverged between rows.
+func TestGetTableFromLODs_MultiLODColumnAlignment(t *testing.T) {
+	loc, _ := time.LoadLocation("")
+	p := tableReqParams{
+		req: seriesRequest{
+			numResults: 100,
+			what:       []promql.SelectorWhat{{Digest: promql.DigestCount}},
+		},
+		metricMeta:     &format.MetricMetaValue{},
+		desiredStepMul: 1,
+		location:       loc,
+	}
+	// two LODs covering disjoint time ranges
+	lods := []data_model.LOD{
+		{FromSec: 100, ToSec: 200, StepSec: 1, Location: loc},
+		{FromSec: 200, ToSec: 300, StepSec: 1, Location: loc},
+	}
+	// one distinct row (distinct time) per LOD
+	load := func(_ context.Context, _ *requestHandler, _ *queryBuilder, lod data_model.LOD, _ bool) ([][]tsSelectRow, error) {
+		row := tsSelectRow{}
+		if lod.FromSec == 100 {
+			row.time = 150
+		} else {
+			row.time = 250
+		}
+		row.count = 1
+		return [][]tsSelectRow{{row}}, nil
+	}
+
+	h := &requestHandler{Handler: &Handler{HandlerOptions: HandlerOptions{location: loc}}}
+	rows, _, err := h.getTableFromLODs(context.Background(), lods, p, load)
+	require.NoError(t, err)
+	require.Len(t, rows, 2, "expected one row per LOD")
+
+	// single what → every row must have exactly one Data column
+	for _, r := range rows {
+		require.Len(t, r.Data, 1, "row at time %d has misaligned Data columns", r.Time)
+	}
+}


### PR DESCRIPTION
pointsCache stored a single loadedAtNano per cache entry, shared across all time ranges of the same query. Loading one range refreshed that timestamp, so an already-invalidated range could be revalidated and served stale. Track loadedAtNano per time range instead.

getTableFromLODs ran the "pad missing rows with NaN" step inside the per-LOD loop. Since each (time, tags) row belongs to exactly one LOD, a row from an earlier LOD got an extra NaN appended for every subsequent LOD, misaligning Data column counts. Pad once per handler-what, after all LODs.

Both paths get a regression test.